### PR TITLE
Fix torchcsprng build with conda and PyTorch CUDA wheel layouts

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,11 +31,75 @@ Secret Sharing.
 
 ## Installation
 
-### Step 1: Clone and Install
+### Step 0: Match torch's CUDA version to your toolkit
+
+Because NssMPClib compiles a CUDA extension at install time, PyTorch's
+`cpp_extension` will refuse to build if `torch.version.cuda` does not match the
+`nvcc` reachable from `CUDA_HOME` (or `/usr/local/cuda`). On hosts that ship
+multiple CUDA toolkits side by side, `setup.py` tries to auto-pick the right
+`/usr/local/cuda-X.Y` for you — but the right toolkit still has to exist on
+the machine.
+
+```bash
+# What CUDA does your torch want?
+python -c "import torch; print(torch.version.cuda)"
+
+# What does your system actually have?
+ls -d /usr/local/cuda-* 2>/dev/null
+```
+
+Suppose `torch.version.cuda` prints `12.8`. Pick one of:
+
+**A. Install the matching toolkit via conda (no sudo, recommended)**
+```bash
+conda install -c nvidia/label/cuda-12.8.0 \
+    cuda-nvcc cuda-cudart-dev cuda-libraries-dev
+```
+
+**B. Install the matching toolkit via apt (Ubuntu)**
+```bash
+# Replace ubuntu2404 with your release (e.g. ubuntu2204):
+wget https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2404/x86_64/cuda-keyring_1.1-1_all.deb
+sudo dpkg -i cuda-keyring_1.1-1_all.deb
+sudo apt-get update
+sudo apt-get install -y cuda-toolkit-12-8
+export CUDA_HOME=/usr/local/cuda-12.8
+```
+
+**C. Reinstall torch to match a toolkit you already have**
+```bash
+# Check your local toolkit version first:
+# nvcc --version  -> Suppose it says 11.8
+pip install torch --index-url https://download.pytorch.org/whl/cu118
+```
+
+**D. Skip the CUDA extension entirely** (runtime falls back to the pure-PyTorch matrix multiplication track under `nssmpc/infra/utils/cuda.py`, which is still GPU-accelerated but lacks Cutlass optimization)
+```bash
+export NSSMPC_SKIP_CUTLASS=1
+```
+
+If you skip Step 0, `setup.py` will still try to auto-detect and align
+`CUDA_HOME`, and on failure it prints the same four options before exiting.
+
+### Step 1: Clone (with submodules) and install
 ```bash
 git clone --recursive https://github.com/XidianNSS/NssMPClib.git
 cd NssMPClib
+# If you forgot --recursive:
+#   git submodule update --init --recursive
+
 pip install -e . --no-build-isolation
+```
+
+`--no-build-isolation` is required because the build needs the already-installed
+torch (otherwise pip would set up a clean env without it). The `setup.py`
+auto-detects `TORCH_CUDA_ARCH_LIST` from the visible GPUs and aligns `CUDA_HOME`
+with `torch.version.cuda` when possible; both can be overridden via env vars.
+
+To install without the CUDA extension (CPU-only, or when no matching toolkit is
+available):
+```bash
+NSSMPC_SKIP_CUTLASS=1 pip install -e . --no-build-isolation
 ```
 
 ### Step 2: Generate Cryptographic Parameters
@@ -200,6 +264,18 @@ Detailed tutorials are available in the `tutorials/` directory:
 
 3. **CUDA Errors**:
    Set `DEVICE: "cpu"` in config or check CUDA installation.
+
+4. **`RuntimeError: The detected CUDA version (X.Y) mismatches ...` at install**:
+   Your system `nvcc` (`/usr/local/cuda/bin/nvcc`) does not match the CUDA
+   version torch was built against. Either install the matching CUDA toolkit
+   (then re-run `pip install -e . --no-build-isolation`), set `CUDA_HOME` to a
+   directory whose `bin/nvcc` matches, reinstall torch from the matching
+   `https://download.pytorch.org/whl/cu*` index, or skip the CUDA extension
+   with `NSSMPC_SKIP_CUTLASS=1`.
+
+5. **`fatal error: cutlass/...: No such file or directory` during build**:
+   Submodules weren't pulled. Run
+   `git submodule update --init --recursive` and reinstall.
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -57,17 +57,24 @@ and rerun the script until it prints an NssMPClib install command.
 
 ### Step 3: Install NssMPClib
 
-Run the command the advice script printed. In the common case it is simply:
+Run the command the advice script printed. In both common cases it is simply:
 
 ```bash
 pip install -e . --no-build-isolation
 ```
 
-`setup.py` auto-detects `CUDA_HOME` (by scanning `/usr/local/cuda-*` for the
-nvcc release matching `torch.version.cuda`) and `TORCH_CUDA_ARCH_LIST` (from
-visible GPUs), so no env-var prefix is needed in the typical case. The advice
-script will tell you when it is (e.g. for a CPU-only or skip-CUDA build, it
-prints the `NSSMPC_SKIP_CUTLASS=1 NSSMPC_SKIP_CSPRNG_CUDA=1` variant).
+- **CUDA torch + matching nvcc + GPU visible**: `setup.py` auto-detects
+  `CUDA_HOME` (by scanning `/usr/local/cuda-*` for the nvcc release matching
+  `torch.version.cuda`) and `TORCH_CUDA_ARCH_LIST` (from visible GPUs), then
+  builds the CUTLASS and CUDA `torchcsprng` extensions.
+- **CPU-only torch**: `setup.py` skips the CUTLASS extension (since
+  `torch.version.cuda` is unset) and `csprng/setup.py` skips its CUDA build
+  (since `torch.cuda.is_available()` is False), so the same command above works
+  as-is — no env vars needed.
+
+The `NSSMPC_SKIP_CUTLASS=1 NSSMPC_SKIP_CSPRNG_CUDA=1` variant is only needed in
+edge cases (CUDA torch installed but nvcc missing / no GPU / broken toolchain);
+the advice script prints it explicitly when applicable.
 
 ### Step 4: Generate cryptographic parameters
 

--- a/README.md
+++ b/README.md
@@ -24,10 +24,17 @@ Secret Sharing.
 
 ## System Requirements
 
-- **OS**: Linux (required for proper compilation)
+- **OS**: Linux is the primary supported platform; Windows works for CPU-only
+  installs (and CUDA installs with matching toolchain) but is less tested.
 - **Python**: 3.10 or higher (recommended: 3.12)
 - **PyTorch**: >=2.3.0 (recommended: 2.7.1)
-- **Additional**: C++ compiler (gcc/g++), CUDA toolkit (for GPU support)
+- **C/C++ compiler**: required because `torchcsprng` always builds a native
+  extension. On Linux: `gcc`/`g++` (e.g. `sudo apt-get install build-essential`).
+  On Windows: install
+  [Build Tools for Visual Studio](https://visualstudio.microsoft.com/visual-cpp-build-tools/)
+  with the "Desktop development with C++" workload.
+- **CUDA toolkit**: optional, only for GPU acceleration. Match the toolkit version
+  to `torch.version.cuda`.
 
 ## Installation
 
@@ -62,6 +69,11 @@ Run the command the advice script printed. In both common cases it is simply:
 ```bash
 pip install -e . --no-build-isolation
 ```
+
+Because `--no-build-isolation` reuses your environment instead of bootstrapping
+a clean one, `setuptools` and `wheel` must already be installed there. The
+advice script flags it explicitly if either is missing; install them with
+`pip install --upgrade setuptools wheel` and rerun.
 
 - **CUDA torch + matching nvcc + GPU visible**: `setup.py` auto-detects
   `CUDA_HOME` (by scanning `/usr/local/cuda-*` for the nvcc release matching

--- a/README.md
+++ b/README.md
@@ -31,10 +31,10 @@ Secret Sharing.
 
 ## Installation
 
-NssMPClib defaults to recommending a CUDA-optimized install when the machine can
-support it. Because PyTorch CUDA extensions require `nvcc` to match
-`torch.version.cuda`, the safest first step is to run the read-only installation
-advice script.
+NssMPClib bundles CUDA extensions and CUTLASS submodules. The included advice
+script inspects your environment (Python, PyTorch, CUDA, nvcc, GPU, submodules)
+and prints the exact install command to run. It is read-only and never installs
+anything itself.
 
 ### Step 1: Clone with submodules
 
@@ -43,95 +43,34 @@ git clone --recursive https://github.com/XidianNSS/NssMPClib.git
 cd NssMPClib
 ```
 
-If you cloned without `--recursive`, initialize the submodules before installing:
+If you cloned without `--recursive`, run `git submodule update --init --recursive`.
 
-```bash
-git submodule update --init --recursive
-```
-
-### Step 2: Ask for installation advice
+### Step 2: Check your environment
 
 ```bash
 python3 scripts/installation_advice.py
 ```
 
-The script does not install anything. It prints the detected Python, PyTorch,
-CUDA, `nvcc`, GPU architecture, and submodule status. Follow its output in
-order:
+If prerequisites (PyTorch, matching CUDA Toolkit / nvcc, submodules) are
+missing, the script prints the commands to fix them. Apply the suggested fix
+and rerun the script until it prints an NssMPClib install command.
 
-1. If it says PyTorch, CUDA Toolkit, `nvcc`, or submodules are missing, install
-   or fix those first.
-2. Rerun `python3 scripts/installation_advice.py`.
-3. When the output says `Run this command to install NssMPClib ...`, run that
-   exact `pip install ...` command.
+### Step 3: Install NssMPClib
 
-### Step 3: Install or fix prerequisites
-
-Skip this step if the advice script already prints an NssMPClib install command.
-
-Typical outcomes:
-
-**A. CUDA PyTorch and matching nvcc are available**
-
-No prerequisite fix is needed. Continue to Step 4 and run the install command
-printed by the advice script.
-
-**B. PyTorch is installed, but matching nvcc is missing**
-
-If `torch.version.cuda` is `12.8`, install CUDA Toolkit / `nvcc` 12.8 with the
-package manager you normally use for CUDA on that machine. On Ubuntu, this is
-typically the NVIDIA CUDA apt repository and `cuda-toolkit-12-8`.
-
-Then rerun:
+Run the command the advice script printed. In the common case it is simply:
 
 ```bash
-python3 scripts/installation_advice.py
+pip install -e . --no-build-isolation
 ```
 
-You can also choose to reinstall PyTorch to match an existing local toolkit; the
-advice script prints the matching `https://download.pytorch.org/whl/cu*` command
-when that applies.
+`setup.py` auto-detects `CUDA_HOME` (by scanning `/usr/local/cuda-*` for the
+nvcc release matching `torch.version.cuda`) and `TORCH_CUDA_ARCH_LIST` (from
+visible GPUs), so no env-var prefix is needed in the typical case. The advice
+script will tell you when it is (e.g. for a CPU-only or skip-CUDA build, it
+prints the `NSSMPC_SKIP_CUTLASS=1 NSSMPC_SKIP_CSPRNG_CUDA=1` variant).
 
-**C. PyTorch is not installed yet**
+### Step 4: Generate cryptographic parameters
 
-Install the PyTorch build recommended by the script, then rerun the advice script.
-For example, on a CUDA 12.8 machine:
-
-```bash
-pip install torch torchvision torchaudio --index-url https://download.pytorch.org/whl/cu128
-python3 scripts/installation_advice.py
-```
-
-### Step 4: Install NssMPClib
-
-Run the NssMPClib install command printed by the advice script.
-
-For CUDA-optimized installs, it will look like:
-
-```bash
-CUDA_HOME=/usr/local/cuda-12.8 TORCH_CUDA_ARCH_LIST='12.0' pip install -e . --no-build-isolation
-```
-
-This builds the bundled CUDA extensions, including the CUTLASS matrix
-multiplication path and CUDA-enabled `torchcsprng`.
-
-For standard compatibility installs, it will look like:
-
-```bash
-NSSMPC_SKIP_CUTLASS=1 NSSMPC_SKIP_CSPRNG_CUDA=1 pip install -e . --no-build-isolation
-```
-
-This skips local CUDA extension compilation and uses the PyTorch fallback paths.
-
-If an install attempt fails because the environment changed or a toolchain was
-fixed, rerun:
-
-```bash
-python3 scripts/installation_advice.py
-```
-
-### Step 5: Generate Cryptographic Parameters
-No matter which pathway you chose, generate the precomputed parameters required for MPC operations:
 ```bash
 python3 scripts/offline_parameter_generation.py
 ```
@@ -293,22 +232,15 @@ Detailed tutorials are available in the `tutorials/` directory:
 3. **CUDA Errors**:
    Set `DEVICE: "cpu"` in config or check CUDA installation.
 
-4. **`RuntimeError: The detected CUDA version (X.Y) mismatches ...` at install**:
-   Your system `nvcc` (`/usr/local/cuda/bin/nvcc`) does not match the CUDA
-   version torch was built against. Either install the matching CUDA toolkit
-   or set `CUDA_HOME` to a directory whose `bin/nvcc` matches. Then rerun:
+4. **Install-time CUDA / submodule errors** (e.g. `RuntimeError: The detected
+   CUDA version (X.Y) mismatches ...`, or `fatal error: cutlass/...: No such
+   file or directory`):
+   Rerun the advice script — it will tell you whether to install a matching
+   CUDA toolkit, reinstall torch, pull submodules, or fall back to the skip-CUDA
+   install:
    ```bash
    python3 scripts/installation_advice.py
    ```
-   You can also reinstall torch from the matching
-   `https://download.pytorch.org/whl/cu*` index, or use the standard install:
-   ```bash
-   NSSMPC_SKIP_CUTLASS=1 NSSMPC_SKIP_CSPRNG_CUDA=1 pip install -e . --no-build-isolation
-   ```
-
-5. **`fatal error: cutlass/...: No such file or directory` during build**:
-   Submodules weren't pulled. Run
-   `git submodule update --init --recursive` and reinstall.
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -31,81 +31,109 @@ Secret Sharing.
 
 ## Installation
 
-### Step 0: Match torch's CUDA version to your toolkit
+NssMPClib defaults to recommending a CUDA-optimized install when the machine can
+support it. Because PyTorch CUDA extensions require `nvcc` to match
+`torch.version.cuda`, the safest first step is to run the read-only installation
+advice script.
 
-Because NssMPClib compiles a CUDA extension at install time, PyTorch's
-`cpp_extension` will refuse to build if `torch.version.cuda` does not match the
-`nvcc` reachable from `CUDA_HOME` (or `/usr/local/cuda`). On hosts that ship
-multiple CUDA toolkits side by side, `setup.py` tries to auto-pick the right
-`/usr/local/cuda-X.Y` for you — but the right toolkit still has to exist on
-the machine.
+### Step 1: Clone with submodules
 
-```bash
-# What CUDA does your torch want?
-python -c "import torch; print(torch.version.cuda)"
-
-# What does your system actually have?
-ls -d /usr/local/cuda-* 2>/dev/null
-```
-
-Suppose `torch.version.cuda` prints `12.8`. Pick one of:
-
-**A. Install the matching toolkit via conda (no sudo, recommended)**
-```bash
-conda install -c nvidia/label/cuda-12.8.0 \
-    cuda-nvcc cuda-cudart-dev cuda-libraries-dev
-```
-
-**B. Install the matching toolkit via apt (Ubuntu)**
-```bash
-# Replace ubuntu2404 with your release (e.g. ubuntu2204):
-wget https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2404/x86_64/cuda-keyring_1.1-1_all.deb
-sudo dpkg -i cuda-keyring_1.1-1_all.deb
-sudo apt-get update
-sudo apt-get install -y cuda-toolkit-12-8
-export CUDA_HOME=/usr/local/cuda-12.8
-```
-
-**C. Reinstall torch to match a toolkit you already have**
-```bash
-# Check your local toolkit version first:
-# nvcc --version  -> Suppose it says 11.8
-pip install torch --index-url https://download.pytorch.org/whl/cu118
-```
-
-**D. Skip the CUDA extension entirely** (runtime falls back to the pure-PyTorch matrix multiplication track under `nssmpc/infra/utils/cuda.py`, which is still GPU-accelerated but lacks Cutlass optimization)
-```bash
-export NSSMPC_SKIP_CUTLASS=1
-```
-
-If you skip Step 0, `setup.py` will still try to auto-detect and align
-`CUDA_HOME`, and on failure it prints the same four options before exiting.
-
-### Step 1: Clone (with submodules) and install
 ```bash
 git clone --recursive https://github.com/XidianNSS/NssMPClib.git
 cd NssMPClib
-# If you forgot --recursive:
-#   git submodule update --init --recursive
-
-pip install -e . --no-build-isolation
 ```
 
-`--no-build-isolation` is required because the build needs the already-installed
-torch (otherwise pip would set up a clean env without it). The `setup.py`
-auto-detects `TORCH_CUDA_ARCH_LIST` from the visible GPUs and aligns `CUDA_HOME`
-with `torch.version.cuda` when possible; both can be overridden via env vars.
+If you cloned without `--recursive`, initialize the submodules before installing:
 
-To install without the CUDA extension (CPU-only, or when no matching toolkit is
-available):
 ```bash
-NSSMPC_SKIP_CUTLASS=1 pip install -e . --no-build-isolation
+git submodule update --init --recursive
 ```
 
-### Step 2: Generate Cryptographic Parameters
-Generate essential precomputed parameters for MPC operations:
+### Step 2: Ask for installation advice
+
 ```bash
-python scripts/offline_parameter_generation.py
+python3 scripts/installation_advice.py
+```
+
+The script does not install anything. It prints the detected Python, PyTorch,
+CUDA, `nvcc`, GPU architecture, and submodule status. Follow its output in
+order:
+
+1. If it says PyTorch, CUDA Toolkit, `nvcc`, or submodules are missing, install
+   or fix those first.
+2. Rerun `python3 scripts/installation_advice.py`.
+3. When the output says `Run this command to install NssMPClib ...`, run that
+   exact `pip install ...` command.
+
+### Step 3: Install or fix prerequisites
+
+Skip this step if the advice script already prints an NssMPClib install command.
+
+Typical outcomes:
+
+**A. CUDA PyTorch and matching nvcc are available**
+
+No prerequisite fix is needed. Continue to Step 4 and run the install command
+printed by the advice script.
+
+**B. PyTorch is installed, but matching nvcc is missing**
+
+If `torch.version.cuda` is `12.8`, install CUDA Toolkit / `nvcc` 12.8 with the
+package manager you normally use for CUDA on that machine. On Ubuntu, this is
+typically the NVIDIA CUDA apt repository and `cuda-toolkit-12-8`.
+
+Then rerun:
+
+```bash
+python3 scripts/installation_advice.py
+```
+
+You can also choose to reinstall PyTorch to match an existing local toolkit; the
+advice script prints the matching `https://download.pytorch.org/whl/cu*` command
+when that applies.
+
+**C. PyTorch is not installed yet**
+
+Install the PyTorch build recommended by the script, then rerun the advice script.
+For example, on a CUDA 12.8 machine:
+
+```bash
+pip install torch torchvision torchaudio --index-url https://download.pytorch.org/whl/cu128
+python3 scripts/installation_advice.py
+```
+
+### Step 4: Install NssMPClib
+
+Run the NssMPClib install command printed by the advice script.
+
+For CUDA-optimized installs, it will look like:
+
+```bash
+CUDA_HOME=/usr/local/cuda-12.8 TORCH_CUDA_ARCH_LIST='12.0' pip install -e . --no-build-isolation
+```
+
+This builds the bundled CUDA extensions, including the CUTLASS matrix
+multiplication path and CUDA-enabled `torchcsprng`.
+
+For standard compatibility installs, it will look like:
+
+```bash
+NSSMPC_SKIP_CUTLASS=1 NSSMPC_SKIP_CSPRNG_CUDA=1 pip install -e . --no-build-isolation
+```
+
+This skips local CUDA extension compilation and uses the PyTorch fallback paths.
+
+If an install attempt fails because the environment changed or a toolchain was
+fixed, rerun:
+
+```bash
+python3 scripts/installation_advice.py
+```
+
+### Step 5: Generate Cryptographic Parameters
+No matter which pathway you chose, generate the precomputed parameters required for MPC operations:
+```bash
+python3 scripts/offline_parameter_generation.py
 ```
 
 **Note**: Parameters are saved to `~/NssMPClib/data/` (32-bit in `data/32/`, 64-bit in `data/64/`).
@@ -256,7 +284,7 @@ Detailed tutorials are available in the `tutorials/` directory:
 
 1. **"Parameters not found" Error**:
    ```bash
-   python scripts/offline_parameter_generation.py
+   python3 scripts/offline_parameter_generation.py
    ```
 
 2. **Port Already in Use**:
@@ -268,10 +296,15 @@ Detailed tutorials are available in the `tutorials/` directory:
 4. **`RuntimeError: The detected CUDA version (X.Y) mismatches ...` at install**:
    Your system `nvcc` (`/usr/local/cuda/bin/nvcc`) does not match the CUDA
    version torch was built against. Either install the matching CUDA toolkit
-   (then re-run `pip install -e . --no-build-isolation`), set `CUDA_HOME` to a
-   directory whose `bin/nvcc` matches, reinstall torch from the matching
-   `https://download.pytorch.org/whl/cu*` index, or skip the CUDA extension
-   with `NSSMPC_SKIP_CUTLASS=1`.
+   or set `CUDA_HOME` to a directory whose `bin/nvcc` matches. Then rerun:
+   ```bash
+   python3 scripts/installation_advice.py
+   ```
+   You can also reinstall torch from the matching
+   `https://download.pytorch.org/whl/cu*` index, or use the standard install:
+   ```bash
+   NSSMPC_SKIP_CUTLASS=1 NSSMPC_SKIP_CSPRNG_CUDA=1 pip install -e . --no-build-isolation
+   ```
 
 5. **`fatal error: cutlass/...: No such file or directory` during build**:
    Submodules weren't pulled. Run

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Secret Sharing.
 - **OS**: Linux is the primary supported platform; Windows works for CPU-only
   installs (and CUDA installs with matching toolchain) but is less tested.
 - **Python**: 3.10 or higher (recommended: 3.12)
-- **PyTorch**: >=2.3.0 (recommended: 2.7.1)
+- **PyTorch**: >=2.5.0 (recommended: 2.7.1 or newer compatible release)
 - **C/C++ compiler**: required because `torchcsprng` always builds a native
   extension. On Linux: `gcc`/`g++` (e.g. `sudo apt-get install build-essential`).
   On Windows: install
@@ -40,8 +40,9 @@ Secret Sharing.
 
 NssMPClib bundles CUDA extensions and CUTLASS submodules. The included advice
 script inspects your environment (Python, PyTorch, CUDA, nvcc, GPU, submodules)
-and prints the exact install command to run. It is read-only and never installs
-anything itself.
+and reports whether the machine is ready to install. It is read-only and never
+installs anything itself; when something is missing, it names the required
+package or version instead of trying to generate platform-specific commands.
 
 ### Step 1: Clone with submodules
 
@@ -59,12 +60,13 @@ python3 scripts/installation_advice.py
 ```
 
 If prerequisites (PyTorch, matching CUDA Toolkit / nvcc, submodules) are
-missing, the script prints the commands to fix them. Apply the suggested fix
-and rerun the script until it prints an NssMPClib install command.
+missing, the script prints a `FAIL` item with the required version or condition.
+Apply the fix that matches your OS/package manager and rerun the script until
+the diagnosis passes or only reports intentional warnings.
 
 ### Step 3: Install NssMPClib
 
-Run the command the advice script printed. In both common cases it is simply:
+Once the check passes, the standard editable install is:
 
 ```bash
 pip install -e . --no-build-isolation
@@ -86,7 +88,8 @@ advice script flags it explicitly if either is missing; install them with
 
 The `NSSMPC_SKIP_CUTLASS=1 NSSMPC_SKIP_CSPRNG_CUDA=1` variant is only needed in
 edge cases (CUDA torch installed but nvcc missing / no GPU / broken toolchain);
-the advice script prints it explicitly when applicable.
+the advice script reports when those skip flags are already part of the selected
+installation path.
 
 ### Step 4: Generate cryptographic parameters
 
@@ -254,9 +257,9 @@ Detailed tutorials are available in the `tutorials/` directory:
 4. **Install-time CUDA / submodule errors** (e.g. `RuntimeError: The detected
    CUDA version (X.Y) mismatches ...`, or `fatal error: cutlass/...: No such
    file or directory`):
-   Rerun the advice script — it will tell you whether to install a matching
-   CUDA toolkit, reinstall torch, pull submodules, or fall back to the skip-CUDA
-   install:
+   Rerun the advice script. It will tell you whether the missing requirement is
+   a matching CUDA Toolkit / nvcc version, a compatible PyTorch build, missing
+   submodules, or an intentional CPU/skip-CUDA path:
    ```bash
    python3 scripts/installation_advice.py
    ```

--- a/csprng/setup.py
+++ b/csprng/setup.py
@@ -1,12 +1,64 @@
 import glob
 import os
+import re
 import shutil
 import subprocess
 import sys
 
-import torch
-from setuptools import Command, find_packages, setup
-from torch.utils.cpp_extension import BuildExtension, CppExtension, CUDAExtension
+
+def _nvcc_release(cuda_home):
+    if not cuda_home:
+        return None
+    nvcc = os.path.join(cuda_home, "bin", "nvcc")
+    if not os.path.isfile(nvcc):
+        return None
+    try:
+        out = subprocess.check_output([nvcc, "--version"], stderr=subprocess.STDOUT).decode("utf-8", "ignore")
+    except (OSError, subprocess.CalledProcessError):
+        return None
+    m = re.search(r"release (\d+\.\d+)", out)
+    return m.group(1) if m else None
+
+
+def _auto_set_cuda_home(torch_cuda):
+    """Align CUDA_HOME to torch.version.cuda.
+
+    Duplicated from NssMPClib/setup.py because pip installs this package in a
+    separate subprocess, so env vars set there don't reach us.
+    """
+    if not torch_cuda:
+        return
+    current = os.environ.get("CUDA_HOME") or "/usr/local/cuda"
+    if _nvcc_release(current) == torch_cuda:
+        return
+    candidates = sorted(glob.glob("/usr/local/cuda-*"), reverse=True)
+    for cand in candidates:
+        if _nvcc_release(cand) == torch_cuda:
+            os.environ["CUDA_HOME"] = cand
+            print(f"Notice: auto-set CUDA_HOME={cand} (matches torch.version.cuda={torch_cuda})")
+            return
+    major = torch_cuda.split(".")[0]
+    for cand in candidates:
+        rel = _nvcc_release(cand)
+        if rel and rel.split(".")[0] == major:
+            os.environ["CUDA_HOME"] = cand
+            print(
+                f"Warning: no exact CUDA {torch_cuda} toolkit found; using {cand} (release {rel})."
+            )
+            return
+    print(
+        f"Warning: torch was built against CUDA {torch_cuda} but no matching "
+        f"/usr/local/cuda-* was found (CUDA_HOME='{os.environ.get('CUDA_HOME')}').",
+        file=sys.stderr,
+    )
+
+
+import torch  # noqa: E402
+
+_auto_set_cuda_home(torch.version.cuda)
+
+from setuptools import Command, find_packages, setup  # noqa: E402
+from torch.utils.cpp_extension import BuildExtension, CppExtension, CUDAExtension  # noqa: E402
 
 version = open("version.txt", "r").read().strip()
 sha = "Unknown"

--- a/csprng/setup.py
+++ b/csprng/setup.py
@@ -1,73 +1,430 @@
 import glob
 import os
 import re
+import shlex
 import shutil
+import site
 import subprocess
 import sys
+
+import torch
+from setuptools import Command, find_packages, setup
+from torch.utils import cpp_extension
+from torch.utils.cpp_extension import BuildExtension, CppExtension, CUDAExtension
+
+
+YES_VALUES = ("1", "true", "yes", "on")
+MIN_TORCH_VERSION = (2, 5, 0)
+
+
+def _version_text(version):
+    return ".".join(str(part) for part in version)
+
+
+def _parse_numeric_version(value):
+    if not value:
+        return None
+
+    match = re.match(r"^\s*(\d+(?:\.\d+)*)", value)
+    if not match:
+        return None
+
+    return tuple(int(part) for part in match.group(1).split("."))
+
+
+def _version_at_least(value, minimum):
+    parsed = _parse_numeric_version(value)
+    if not parsed:
+        return False
+
+    size = max(len(parsed), len(minimum))
+    padded = parsed + (0,) * (size - len(parsed))
+    padded_minimum = minimum + (0,) * (size - len(minimum))
+    return padded >= padded_minimum
+
+
+def _version_less_than(value, maximum):
+    parsed = _parse_numeric_version(value)
+    if not parsed:
+        return False
+
+    size = max(len(parsed), len(maximum))
+    padded = parsed + (0,) * (size - len(parsed))
+    padded_maximum = maximum + (0,) * (size - len(maximum))
+    return padded < padded_maximum
+
+
+def _env_enabled(name):
+    return os.environ.get(name, "").strip().lower() in YES_VALUES
+
+
+def _ensure_torch_version():
+    version = getattr(torch, "__version__", None)
+    if _version_at_least(version, MIN_TORCH_VERSION):
+        return
+
+    raise RuntimeError(
+        "PyTorch is too old for bundled torchcsprng.\n"
+        f"Required: torch >= {_version_text(MIN_TORCH_VERSION)}.\n"
+        f"Current torch: {version or '<unknown>'}."
+    )
 
 
 def _nvcc_release(cuda_home):
     if not cuda_home:
         return None
+
     nvcc = os.path.join(cuda_home, "bin", "nvcc")
     if not os.path.isfile(nvcc):
         return None
+
     try:
-        out = subprocess.check_output([nvcc, "--version"], stderr=subprocess.STDOUT).decode("utf-8", "ignore")
+        out = subprocess.check_output(
+            [nvcc, "--version"],
+            stderr=subprocess.STDOUT,
+        ).decode("utf-8", "ignore")
     except (OSError, subprocess.CalledProcessError):
         return None
-    m = re.search(r"release (\d+\.\d+)", out)
-    return m.group(1) if m else None
+
+    match = re.search(r"release\s+(\d+\.\d+)", out)
+    return match.group(1) if match else None
 
 
-def _auto_set_cuda_home(torch_cuda):
-    """Align CUDA_HOME to torch.version.cuda.
+def _dedupe_existing_paths(paths):
+    result = []
+    seen = set()
 
-    Duplicated from NssMPClib/setup.py because pip installs this package in a
-    separate subprocess, so env vars set there don't reach us.
+    for path in paths:
+        if not path:
+            continue
+
+        path = os.path.abspath(path)
+
+        if path in seen:
+            continue
+
+        if os.path.isdir(path):
+            seen.add(path)
+            result.append(path)
+
+    return result
+
+
+def _cuda_home_candidates():
+    """Return possible CUDA roots.
+
+    Supports:
+      - system CUDA: /usr/local/cuda, /usr/local/cuda-*
+      - conda CUDA: $CONDA_PREFIX
+      - nvcc discovered on PATH
+      - manually configured CUDA_HOME / CUDA_PATH
     """
-    if not torch_cuda:
-        return
-    current = os.environ.get("CUDA_HOME") or "/usr/local/cuda"
-    if _nvcc_release(current) == torch_cuda:
-        return
-    candidates = sorted(glob.glob("/usr/local/cuda-*"), reverse=True)
-    for cand in candidates:
-        if _nvcc_release(cand) == torch_cuda:
-            os.environ["CUDA_HOME"] = cand
-            print(f"Notice: auto-set CUDA_HOME={cand} (matches torch.version.cuda={torch_cuda})")
-            return
-    major = torch_cuda.split(".")[0]
-    for cand in candidates:
-        rel = _nvcc_release(cand)
-        if rel and rel.split(".")[0] == major:
-            os.environ["CUDA_HOME"] = cand
-            print(
-                f"Warning: no exact CUDA {torch_cuda} toolkit found; using {cand} (release {rel})."
-            )
-            return
-    print(
-        f"Warning: torch was built against CUDA {torch_cuda} but no matching "
-        f"/usr/local/cuda-* was found (CUDA_HOME='{os.environ.get('CUDA_HOME')}').",
-        file=sys.stderr,
+    candidates = []
+
+    for env_name in ("CUDA_HOME", "CUDA_PATH", "CONDA_PREFIX"):
+        value = os.environ.get(env_name)
+        if value:
+            candidates.append(value)
+
+    if cpp_extension.CUDA_HOME:
+        candidates.append(cpp_extension.CUDA_HOME)
+
+    path_nvcc = shutil.which("nvcc")
+    if path_nvcc:
+        candidates.append(os.path.dirname(os.path.dirname(path_nvcc)))
+
+    candidates.append("/usr/local/cuda")
+    candidates.extend(sorted(glob.glob("/usr/local/cuda-*"), reverse=True))
+
+    result = []
+    seen = set()
+
+    for candidate in candidates:
+        if not candidate:
+            continue
+
+        candidate = os.path.abspath(candidate)
+
+        if candidate in seen:
+            continue
+
+        seen.add(candidate)
+        result.append(candidate)
+
+    return result
+
+
+def _python_site_dirs():
+    dirs = []
+
+    try:
+        dirs.extend(site.getsitepackages())
+    except Exception:
+        pass
+
+    try:
+        user_site = site.getusersitepackages()
+        if user_site:
+            dirs.append(user_site)
+    except Exception:
+        pass
+
+    conda_prefix = os.environ.get("CONDA_PREFIX")
+    if conda_prefix:
+        pattern = os.path.join(conda_prefix, "lib", "python*", "site-packages")
+        dirs.extend(glob.glob(pattern))
+
+    return _dedupe_existing_paths(dirs)
+
+
+def _cuda_include_dirs():
+    """Return CUDA include directories.
+
+    Handles:
+      - /usr/local/cuda*/include
+      - $CONDA_PREFIX/include
+      - $CONDA_PREFIX/targets/x86_64-linux/include
+      - pip NVIDIA wheels: site-packages/nvidia/*/include
+    """
+    candidates = []
+
+    for root in _cuda_home_candidates():
+        candidates.extend(
+            [
+                os.path.join(root, "include"),
+                os.path.join(root, "targets", "x86_64-linux", "include"),
+            ]
+        )
+
+    for site_dir in _python_site_dirs():
+        candidates.extend(glob.glob(os.path.join(site_dir, "nvidia", "*", "include")))
+
+    return _dedupe_existing_paths(candidates)
+
+
+def _cuda_library_dirs():
+    """Return CUDA library directories.
+
+    Handles:
+      - /usr/local/cuda*/lib64
+      - $CONDA_PREFIX/lib
+      - $CONDA_PREFIX/targets/x86_64-linux/lib
+      - pip NVIDIA wheels: site-packages/nvidia/*/lib
+    """
+    candidates = []
+
+    for root in _cuda_home_candidates():
+        candidates.extend(
+            [
+                os.path.join(root, "lib64"),
+                os.path.join(root, "lib"),
+                os.path.join(root, "targets", "x86_64-linux", "lib"),
+                os.path.join(root, "targets", "x86_64-linux", "lib", "stubs"),
+            ]
+        )
+
+    for site_dir in _python_site_dirs():
+        candidates.extend(glob.glob(os.path.join(site_dir, "nvidia", "*", "lib")))
+
+    return _dedupe_existing_paths(candidates)
+
+
+def _find_header(header_name, include_dirs):
+    for include_dir in include_dirs:
+        candidate = os.path.join(include_dir, header_name)
+        if os.path.exists(candidate):
+            return candidate
+    return None
+
+
+def _ensure_cuda_headers(include_dirs):
+    required_headers = [
+        "cuda_runtime.h",
+        "cublas_v2.h",
+    ]
+
+    missing = []
+    found = {}
+
+    for header in required_headers:
+        path = _find_header(header, include_dirs)
+        if path:
+            found[header] = path
+        else:
+            missing.append(header)
+
+    if missing:
+        lines = [
+            "Error: CUDA development headers are missing.",
+            "",
+            "Missing headers:",
+        ]
+
+        for header in missing:
+            lines.append(f"  - {header}")
+
+        lines.extend(
+            [
+                "",
+                "Checked include directories:",
+            ]
+        )
+
+        if include_dirs:
+            for include_dir in include_dirs:
+                lines.append(f"  - {include_dir}")
+        else:
+            lines.append("  <none>")
+
+        lines.extend(
+            [
+                "",
+                "This usually means nvcc is available, but CUDA development headers",
+                "are not installed or are not visible to the build system.",
+                "",
+                "For pip/PyTorch CUDA wheels, headers may live under:",
+                "  site-packages/nvidia/*/include",
+                "",
+                "For conda/miniforge CUDA environments, headers may live under:",
+                "  $CONDA_PREFIX/targets/x86_64-linux/include",
+                "",
+                "To skip CUDA support for torchcsprng, set:",
+                "  NSSMPC_SKIP_CSPRNG_CUDA=1",
+            ]
+        )
+
+        raise RuntimeError("\n".join(lines))
+
+    print("Detected CUDA headers:")
+    for header, path in found.items():
+        print(f"  {header}: {path}")
+
+
+def _cxx_compiler_command():
+    env_cxx = os.environ.get("CXX")
+    if env_cxx:
+        return shlex.split(env_cxx)
+
+    if sys.platform.startswith("win"):
+        return ["cl"] if shutil.which("cl") else None
+
+    for name in ("g++", "c++", "clang++"):
+        if shutil.which(name):
+            return [name]
+
+    return None
+
+
+def _compiler_version(command):
+    for args in (command + ["-dumpfullversion", "-dumpversion"], command + ["--version"]):
+        try:
+            out = subprocess.check_output(args, stderr=subprocess.STDOUT).decode("utf-8", "ignore")
+        except (OSError, subprocess.CalledProcessError):
+            continue
+
+        parsed = _parse_numeric_version(out)
+        if parsed:
+            return _version_text(parsed)
+
+    return None
+
+
+def _compiler_kind(command):
+    name = os.path.basename(command[0]).lower()
+    if "clang" in name:
+        return "clang"
+    return "gcc"
+
+
+def _cuda_compiler_issue(torch_cuda):
+    if not torch_cuda or not sys.platform.startswith("linux"):
+        return None
+
+    if os.environ.get("TORCH_DONT_CHECK_COMPILER_ABI", "").upper() in (
+        "ON",
+        "1",
+        "YES",
+        "TRUE",
+        "Y",
+    ):
+        return None
+
+    command = _cxx_compiler_command()
+    if not command:
+        return "No C++ compiler command was found for CUDA extension builds."
+
+    version = _compiler_version(command)
+    if not version:
+        return f"Could not determine C++ compiler version for {' '.join(command)}."
+
+    kind = _compiler_kind(command)
+    bounds_map = (
+        getattr(cpp_extension, "CUDA_CLANG_VERSIONS", {})
+        if kind == "clang"
+        else getattr(cpp_extension, "CUDA_GCC_VERSIONS", {})
+    )
+    bounds = bounds_map.get(torch_cuda)
+    if not bounds:
+        return None
+
+    min_version, max_exclusive_version = tuple(bounds[0]), tuple(bounds[1])
+    if _version_at_least(version, min_version) and _version_less_than(version, max_exclusive_version):
+        return None
+
+    compiler_name = "clang++" if kind == "clang" else "g++"
+    return (
+        f"Detected {compiler_name}-compatible compiler {' '.join(command)} {version}, "
+        f"but CUDA {torch_cuda} requires {compiler_name} "
+        f">= {_version_text(min_version)}, < {_version_text(max_exclusive_version)} "
+        "for PyTorch CUDA extension builds."
     )
 
 
-import torch  # noqa: E402
+def _ensure_cuda_compiler_compatible(torch_cuda):
+    issue = _cuda_compiler_issue(torch_cuda)
+    if issue:
+        raise RuntimeError(
+            "C++ compiler version is incompatible with this CUDA/PyTorch build.\n"
+            f"Reason: {issue}\n"
+            "Required: use a host C++ compiler version within PyTorch's CUDA compiler bounds, "
+            "or set NSSMPC_SKIP_CSPRNG_CUDA=1 for an intentional CPU-only torchcsprng build."
+        )
 
-_auto_set_cuda_home(torch.version.cuda)
 
-from setuptools import Command, find_packages, setup  # noqa: E402
-from torch.utils import cpp_extension  # noqa: E402
-from torch.utils.cpp_extension import BuildExtension, CppExtension, CUDAExtension  # noqa: E402
+def _auto_set_cuda_home(torch_cuda):
+    """Align CUDA_HOME to torch.version.cuda when possible.
 
-if os.environ.get("CUDA_HOME"):
-    cpp_extension.CUDA_HOME = os.environ["CUDA_HOME"]
+    This supports both system CUDA and conda/miniforge CUDA layouts.
+    """
+    if not torch_cuda:
+        return True
+
+    current = os.environ.get("CUDA_HOME")
+    if current and _nvcc_release(current) == torch_cuda:
+        os.environ.setdefault("CUDA_PATH", current)
+        return True
+
+    candidates = _cuda_home_candidates()
+
+    for candidate in candidates:
+        if _nvcc_release(candidate) == torch_cuda:
+            os.environ["CUDA_HOME"] = candidate
+            os.environ.setdefault("CUDA_PATH", candidate)
+            print(
+                f"Notice: auto-set CUDA_HOME={candidate} "
+                f"(matches torch.version.cuda={torch_cuda})"
+            )
+            return True
+
+    return False
+
+
+_ensure_torch_version()
+
 
 version = open("version.txt", "r").read().strip()
 sha = "Unknown"
 package_name = "torchcsprng"
-
 cwd = os.path.dirname(os.path.abspath(__file__))
 
 try:
@@ -83,6 +440,7 @@ if os.getenv("BUILD_VERSION"):
     version = os.getenv("BUILD_VERSION")
 elif sha != "Unknown":
     version += "+" + sha[:7]
+
 print(f"Building wheel {package_name}-{version}")
 
 
@@ -91,9 +449,6 @@ def write_version_file():
     with open(version_path, "w") as f:
         f.write("__version__ = '{}'\n".format(version))
         f.write("git_version = {}\n".format(repr(sha)))
-        # f.write("from torchcsprng.extension import _check_cuda_version\n")
-        # f.write("if _check_cuda_version() > 0:\n")
-        # f.write("    cuda = _check_cuda_version()\n")
 
 
 write_version_file()
@@ -104,19 +459,25 @@ with open("README.md", "r") as fh:
 
 def append_flags(flags, flags_to_append):
     for flag in flags_to_append:
-        if not flag in flags:
+        if flag not in flags:
             flags.append(flag)
     return flags
 
 
 def get_extensions():
-    skip_cuda = os.getenv("NSSMPC_SKIP_CSPRNG_CUDA", "").lower() in ("1", "true", "yes")
-    build_cuda = not skip_cuda and (torch.cuda.is_available() or os.getenv("FORCE_CUDA", "0") == "1")
+    skip_cuda = _env_enabled("NSSMPC_SKIP_CSPRNG_CUDA")
+
+    build_cuda = not skip_cuda and (
+        torch.cuda.is_available() or os.getenv("FORCE_CUDA", "0") == "1"
+    )
+
     if skip_cuda:
-        print("Notice: NSSMPC_SKIP_CSPRNG_CUDA is set; building torchcsprng without CUDA support.")
+        print(
+            "Notice: NSSMPC_SKIP_CSPRNG_CUDA is set; "
+            "building torchcsprng without CUDA support."
+        )
 
     module_name = "torchcsprng"
-
     extensions_dir = os.path.join(cwd, module_name, "csrc")
 
     openmp = "ATen parallel backend: OpenMP" in torch.__config__.parallel_info()
@@ -126,7 +487,6 @@ def get_extensions():
 
     sources = main_file + source_cpu
     extension = CppExtension
-
     define_macros = []
 
     cxx_flags = os.getenv("CXX_FLAGS", "")
@@ -134,31 +494,74 @@ def get_extensions():
         cxx_flags = []
     else:
         cxx_flags = cxx_flags.split(" ")
+
     if openmp:
         if sys.platform == "linux":
             cxx_flags = append_flags(cxx_flags, ["-fopenmp"])
         elif sys.platform == "win32":
             cxx_flags = append_flags(cxx_flags, ["/openmp"])
-        # elif sys.platform == 'darwin':
-        #     cxx_flags = append_flags(cxx_flags, ['-Xpreprocessor', '-fopenmp'])
+
+    include_dirs = []
+    library_dirs = []
 
     if build_cuda:
+        if not _auto_set_cuda_home(torch.version.cuda):
+            raise RuntimeError(
+                "CUDA PyTorch is installed, but no matching CUDA Toolkit / nvcc "
+                "was found for bundled torchcsprng.\n"
+                f"Required: CUDA Toolkit / nvcc {torch.version.cuda}, "
+                "matching torch.version.cuda."
+            )
+
+        if os.environ.get("CUDA_HOME"):
+            cpp_extension.CUDA_HOME = os.environ["CUDA_HOME"]
+
         extension = CUDAExtension
+
         source_cuda = glob.glob(os.path.join(extensions_dir, "cuda", "*.cu"))
         sources += source_cuda
 
         define_macros += [("WITH_CUDA", None)]
+
+        include_dirs = _cuda_include_dirs()
+        library_dirs = _cuda_library_dirs()
+
+        _ensure_cuda_headers(include_dirs)
+        _ensure_cuda_compiler_compatible(torch.version.cuda)
 
         nvcc_flags = os.getenv("NVCC_FLAGS", "")
         if nvcc_flags == "":
             nvcc_flags = []
         else:
             nvcc_flags = nvcc_flags.split(" ")
-        nvcc_flags = append_flags(nvcc_flags, ["--expt-extended-lambda", "-Xcompiler"])
+
+        for include_dir in include_dirs:
+            nvcc_flags = append_flags(nvcc_flags, [f"-I{include_dir}"])
+
+        nvcc_flags = append_flags(
+            nvcc_flags,
+            [
+                "--expt-extended-lambda",
+                "-Xcompiler",
+            ],
+        )
+
         extra_compile_args = {
             "cxx": cxx_flags,
             "nvcc": nvcc_flags,
         }
+
+        print("Building torchcsprng with CUDA support.")
+        print("CUDA_HOME:", os.environ.get("CUDA_HOME") or "<unset>")
+
+        print("CUDA include dirs:")
+        for include_dir in include_dirs:
+            print(f"  - {include_dir}")
+
+        print("CUDA library dirs:")
+        for library_dir in library_dirs:
+            print(f"  - {library_dir}")
+
     else:
         extra_compile_args = {
             "cxx": cxx_flags,
@@ -169,6 +572,8 @@ def get_extensions():
             module_name + "._C",
             sources,
             define_macros=define_macros,
+            include_dirs=include_dirs,
+            library_dirs=library_dirs,
             extra_compile_args=extra_compile_args,
         )
     ]
@@ -178,13 +583,13 @@ def get_extensions():
 
 class fast_install(Command):
     description = "Custom install command that cleans project and installs wheel"
-    user_options = []  # Required variable
+    user_options = []
 
     def initialize_options(self):
-        pass  # Required method
+        pass
 
     def finalize_options(self):
-        pass  # Required method
+        pass
 
     def run(self):
         os.system("python setup.py clean")
@@ -194,34 +599,40 @@ class fast_install(Command):
 
 class clean(Command):
     description = "Custom clean command that cleans project based on .gitignore rules"
-    user_options = []  # Required variable
+    user_options = []
 
     def initialize_options(self):
-        pass  # Required method
+        pass
 
     def finalize_options(self):
-        pass  # Required method
+        pass
 
     def run(self):
         with open(".gitignore", "r") as f:
             ignores = f.read()
+
         start_deleting = False
+
         for wildcard in filter(None, ignores.split("\n")):
-            if wildcard == "# do not change or delete this comment - `python setup.py clean` deletes everything after this line":
+            if (
+                wildcard
+                == "# do not change or delete this comment - `python setup.py clean` deletes everything after this line"
+            ):
                 start_deleting = True
+
             if not start_deleting:
                 continue
+
             for filename in glob.glob(wildcard, recursive=True):
                 try:
                     os.remove(filename)
                     print(f"Removed file: {filename}")
-                except OSError as e:
+                except OSError:
                     shutil.rmtree(filename, ignore_errors=True)
                     print(f"Removed directory: {filename}")
 
 
 setup(
-    # Metadata
     name=package_name,
     version=version,
     author="Pavel Belevich",
@@ -231,7 +642,6 @@ setup(
     long_description=long_description,
     long_description_content_type="text/markdown",
     license="BSD-3",
-    # Package info
     packages=find_packages(exclude=("test",)),
     package_data={"": ["*.pyi"]},
     classifiers=[
@@ -248,8 +658,8 @@ setup(
         "Topic :: Software Development :: Libraries",
         "Topic :: Software Development :: Libraries :: Python Modules",
     ],
-    python_requires=">=3.6",
-    install_requires="torch>=2.3.0",
+    python_requires=">=3.10",
+    install_requires="torch>=2.5.0",
     ext_modules=get_extensions(),
     test_suite="test",
     cmdclass={

--- a/csprng/setup.py
+++ b/csprng/setup.py
@@ -58,7 +58,11 @@ import torch  # noqa: E402
 _auto_set_cuda_home(torch.version.cuda)
 
 from setuptools import Command, find_packages, setup  # noqa: E402
+from torch.utils import cpp_extension  # noqa: E402
 from torch.utils.cpp_extension import BuildExtension, CppExtension, CUDAExtension  # noqa: E402
+
+if os.environ.get("CUDA_HOME"):
+    cpp_extension.CUDA_HOME = os.environ["CUDA_HOME"]
 
 version = open("version.txt", "r").read().strip()
 sha = "Unknown"
@@ -106,7 +110,10 @@ def append_flags(flags, flags_to_append):
 
 
 def get_extensions():
-    build_cuda = torch.cuda.is_available() or os.getenv("FORCE_CUDA", "0") == "1"
+    skip_cuda = os.getenv("NSSMPC_SKIP_CSPRNG_CUDA", "").lower() in ("1", "true", "yes")
+    build_cuda = not skip_cuda and (torch.cuda.is_available() or os.getenv("FORCE_CUDA", "0") == "1")
+    if skip_cuda:
+        print("Notice: NSSMPC_SKIP_CSPRNG_CUDA is set; building torchcsprng without CUDA support.")
 
     module_name = "torchcsprng"
 

--- a/nssmpc/config/config.json
+++ b/nssmpc/config/config.json
@@ -1,0 +1,14 @@
+{
+  "BIT_LEN": 32,
+  "LAMBDA": 128,
+  "GE_TYPE": "SIGMA",
+  "PRG_TYPE": "AES",
+  "DEVICE": "cuda",
+  "DEBUG_LEVEL": 2,
+  "DTYPE": "float",
+  "SCALE_BIT": 8,
+  "EXP_ITER": 8,
+  "GELU_TABLE_BIT": 6,
+  "TANH_TABLE_BIT": 7,
+  "VCMP_SPLIT_LEN": 8
+}

--- a/scripts/installation_advice.py
+++ b/scripts/installation_advice.py
@@ -22,6 +22,15 @@ from typing import Iterable
 
 YES_VALUES = {"1", "true", "yes", "on"}
 
+# CUDA versions for which PyTorch publishes a cu* wheel index.
+# Keep sorted ascending; recommendations always pick the highest entry that is
+# <= the driver-supported CUDA or local nvcc release.
+PYTORCH_CUDA_INDEXES = ("11.8", "12.1", "12.4", "12.6", "12.8")
+
+# Minimum CUDA compute capability supported by modern PyTorch wheels (sm_50).
+# Cards below this (Kepler sm_3.x and earlier) cannot run cu* wheels.
+MIN_PYTORCH_COMPUTE_CAP = (5, 0)
+
 
 @dataclass(frozen=True)
 class NvccInfo:
@@ -145,6 +154,80 @@ def detect_nvidia_smi() -> tuple[bool, str | None]:
     return True, out
 
 
+def _parse_version(value: str | None) -> tuple[int, int] | None:
+    if not value:
+        return None
+    m = re.match(r"^\s*(\d+)\.(\d+)", value)
+    return (int(m.group(1)), int(m.group(2))) if m else None
+
+
+def nvidia_smi_driver_cuda() -> str | None:
+    """Max CUDA version the NVIDIA driver supports, parsed from `nvidia-smi` header."""
+    smi = shutil.which("nvidia-smi")
+    if not smi:
+        return None
+    code, out = run_cmd([smi])
+    if code != 0:
+        return None
+    m = re.search(r"CUDA Version:\s*([\d.]+)", out)
+    return m.group(1) if m else None
+
+
+def nvidia_smi_compute_caps() -> list[str]:
+    """Per-GPU compute capability strings from `nvidia-smi --query-gpu=compute_cap`."""
+    smi = shutil.which("nvidia-smi")
+    if not smi:
+        return []
+    code, out = run_cmd([smi, "--query-gpu=compute_cap", "--format=csv,noheader,nounits"])
+    if code != 0:
+        return []
+    return [line.strip() for line in out.splitlines() if line.strip()]
+
+
+def pytorch_cu_index_for(cuda_version: str | None) -> str | None:
+    """Highest entry in PYTORCH_CUDA_INDEXES that is <= cuda_version."""
+    target = _parse_version(cuda_version)
+    if not target:
+        return None
+    best: tuple[int, int] | None = None
+    best_str: str | None = None
+    for v in PYTORCH_CUDA_INDEXES:
+        parsed = _parse_version(v)
+        if parsed and parsed <= target and (best is None or parsed > best):
+            best = parsed
+            best_str = v
+    return best_str
+
+
+def recommended_cuda_torch_index(
+    nvccs: list[NvccInfo], driver_cuda: str | None
+) -> tuple[str, str] | None:
+    """Pick the best (cuda_version, wheel_index_url) for installing PyTorch.
+
+    Prefers a wheel matching a local nvcc release (so the user can also build
+    NssMPClib's CUDA extensions with that nvcc), then falls back to the
+    driver-supported max CUDA. Returns None when nothing in
+    PYTORCH_CUDA_INDEXES fits.
+    """
+    preferred = preferred_nvcc(nvccs)
+    if preferred and preferred.release:
+        picked = pytorch_cu_index_for(preferred.release)
+        if picked:
+            return picked, torch_index(picked)
+    picked = pytorch_cu_index_for(driver_cuda)
+    if picked:
+        return picked, torch_index(picked)
+    return None
+
+
+def all_compute_caps_too_old(caps: Iterable[str]) -> bool:
+    """True iff at least one cap was reported and the max is below MIN_PYTORCH_COMPUTE_CAP."""
+    parsed = [p for p in (_parse_version(c) for c in caps) if p]
+    if not parsed:
+        return False
+    return max(parsed) < MIN_PYTORCH_COMPUTE_CAP
+
+
 def ubuntu_codename() -> str | None:
     os_release = Path("/etc/os-release")
     if not os_release.exists():
@@ -209,6 +292,56 @@ def submodule_status(root: Path) -> list[str]:
     return missing
 
 
+def detect_missing_build_deps() -> list[str]:
+    """Return missing names from ('setuptools', 'wheel') that --no-build-isolation needs."""
+    missing = []
+    for name in ("setuptools", "wheel"):
+        try:
+            __import__(name)
+        except ImportError:
+            missing.append(name)
+    return missing
+
+
+def detect_cpp_compiler() -> tuple[bool, str | None]:
+    """Best-effort detection of a C/C++ compiler that PyTorch can use for extension builds.
+
+    Returns (has_compiler, advice_message). torchcsprng always builds a native
+    extension, so this is required regardless of CUDA path.
+    """
+    if platform.system() == "Windows":
+        if shutil.which("cl"):
+            return True, None
+        # Look for an actual cl.exe inside common VS / Build Tools layouts —
+        # directory existence alone isn't enough (installer leaves empty stubs).
+        cl_patterns = [
+            r"C:\Program Files\Microsoft Visual Studio\*\*\VC\Tools\MSVC\*\bin\Host*\*\cl.exe",
+            r"C:\Program Files (x86)\Microsoft Visual Studio\*\*\VC\Tools\MSVC\*\bin\Host*\*\cl.exe",
+            r"C:\BuildTools\VC\Tools\MSVC\*\bin\Host*\*\cl.exe",
+        ]
+        if any(glob.glob(p) for p in cl_patterns):
+            return False, (
+                "Microsoft Visual C++ appears to be installed but 'cl' is not on PATH. "
+                "Open the 'x64 Native Tools Command Prompt for VS' (or run vcvarsall.bat) "
+                "before retrying, so that the compiler is reachable."
+            )
+        return False, (
+            "Building torchcsprng's C++ extension requires Microsoft Visual C++ 14.0 or newer. "
+            "Install 'Build Tools for Visual Studio' (free) from "
+            "https://visualstudio.microsoft.com/visual-cpp-build-tools/ "
+            "with the 'Desktop development with C++' workload, then open the "
+            "'x64 Native Tools Command Prompt for VS' (so 'cl' is on PATH) before retrying."
+        )
+    # Unix-like
+    for name in ("c++", "g++", "clang++", "cc", "gcc", "clang"):
+        if shutil.which(name):
+            return True, None
+    return False, (
+        "Building C/C++ extensions requires a system C++ compiler (gcc/g++ or clang). "
+        "On Ubuntu/Debian: sudo apt-get install build-essential."
+    )
+
+
 def print_section(title: str) -> None:
     print(f"\n{title}")
     print("-" * len(title))
@@ -222,6 +355,7 @@ def print_command(command: str, intro: str = "Run this command:") -> None:
 
 def recommend(root: Path, torch_info: TorchInfo, nvccs: list[NvccInfo]) -> None:
     missing_submodules = submodule_status(root)
+    missing_build_deps = detect_missing_build_deps()
     skip_cutlass = env_enabled("NSSMPC_SKIP_CUTLASS")
     skip_csprng_cuda = env_enabled("NSSMPC_SKIP_CSPRNG_CUDA")
 
@@ -230,6 +364,30 @@ def recommend(root: Path, torch_info: TorchInfo, nvccs: list[NvccInfo]) -> None:
     if missing_submodules:
         print("Submodules are missing, so installation should start here:")
         print_command("git submodule update --init --recursive")
+        print("Then rerun: python3 scripts/installation_advice.py")
+        return
+
+    if missing_build_deps:
+        print(
+            "Build dependencies for --no-build-isolation are missing: "
+            + ", ".join(missing_build_deps)
+            + ". pip needs them to run the editable build and produce a wheel."
+        )
+        print_command(
+            "pip install --upgrade " + " ".join(missing_build_deps),
+            "Run this command to install them:",
+        )
+        print("Then rerun: python3 scripts/installation_advice.py")
+        return
+
+    has_compiler, compiler_advice = detect_cpp_compiler()
+    if not has_compiler:
+        print(
+            "No C/C++ compiler was detected, but torchcsprng's native extension must "
+            "be compiled from source."
+        )
+        if compiler_advice:
+            print(compiler_advice)
         print("Then rerun: python3 scripts/installation_advice.py")
         return
 
@@ -245,22 +403,68 @@ def recommend(root: Path, torch_info: TorchInfo, nvccs: list[NvccInfo]) -> None:
 
     if not torch_info.installed:
         print("PyTorch is not installed, so CUDA capability cannot be evaluated yet.")
-        print("Install a PyTorch build that matches your GPU/driver first.")
-        preferred = preferred_nvcc(nvccs)
-        if preferred and preferred.release:
-            print(f"The newest detected local nvcc is CUDA {preferred.release} at {preferred.path}.")
+        has_smi, _ = detect_nvidia_smi()
+        driver_cuda = nvidia_smi_driver_cuda()
+        compute_caps = nvidia_smi_compute_caps()
+
+        if not has_smi and not nvccs:
+            print("No CUDA toolchain or NVIDIA driver detected; this looks like a CPU-only host.")
             print_command(
-                "pip install torch torchvision torchaudio "
-                f"--index-url {torch_index(preferred.release)}",
-                "Run this command to install a matching PyTorch build:",
+                "pip install torch torchvision torchaudio --index-url https://download.pytorch.org/whl/cpu",
+                "Run this command to install CPU PyTorch:",
+            )
+            print("Then rerun: python3 scripts/installation_advice.py")
+            return
+
+        if all_compute_caps_too_old(compute_caps):
+            cap_str = ", ".join(compute_caps) if compute_caps else "<unknown>"
+            min_cap = f"sm_{MIN_PYTORCH_COMPUTE_CAP[0]}{MIN_PYTORCH_COMPUTE_CAP[1]}"
+            print(
+                f"NVIDIA driver detected, but GPU compute capability ({cap_str}) is below "
+                f"{min_cap}, which recent PyTorch CUDA wheels do not support."
+            )
+            print_command(
+                "pip install torch torchvision torchaudio --index-url https://download.pytorch.org/whl/cpu",
+                "Run this command to install CPU PyTorch instead:",
+            )
+            print("Then rerun: python3 scripts/installation_advice.py")
+            return
+
+        picked = recommended_cuda_torch_index(nvccs, driver_cuda)
+        if picked:
+            cu_version, cu_url = picked
+            label = f"cu{cu_version.replace('.', '')}"
+            context_parts = []
+            preferred = preferred_nvcc(nvccs)
+            if preferred and preferred.release:
+                context_parts.append(f"local nvcc {preferred.release}")
+            if driver_cuda:
+                context_parts.append(f"driver max CUDA {driver_cuda}")
+            context = "; ".join(context_parts) or "GPU present"
+            print(f"Choosing PyTorch {label} ({context}).")
+            print_command(
+                f"pip install torch torchvision torchaudio --index-url {cu_url}",
+                f"Run this command to install a CUDA PyTorch build ({label}):",
+            )
+            print("Then rerun: python3 scripts/installation_advice.py")
+            return
+
+        if driver_cuda:
+            print(
+                f"NVIDIA driver detected but max supported CUDA ({driver_cuda}) is below the "
+                f"lowest PyTorch CUDA wheel (cu{PYTORCH_CUDA_INDEXES[0].replace('.', '')}). "
+                "Update the NVIDIA driver, or install CPU PyTorch:"
             )
         else:
-            print_command(
-                "pip install torch torchvision torchaudio --index-url https://download.pytorch.org/whl/cu128",
-                "Run this command to install a CUDA PyTorch build:",
+            print(
+                "NVIDIA driver detected but its CUDA support could not be determined. "
+                "Falling back to CPU PyTorch:"
             )
+        print_command(
+            "pip install torch torchvision torchaudio --index-url https://download.pytorch.org/whl/cpu",
+            "Run this command to install CPU PyTorch:",
+        )
         print("Then rerun: python3 scripts/installation_advice.py")
-        print("If your machine is CPU-only, use the standard install after installing CPU PyTorch.")
         return
 
     if torch_info.cuda_version and torch_info.cuda_available:
@@ -339,18 +543,22 @@ def recommend(root: Path, torch_info: TorchInfo, nvccs: list[NvccInfo]) -> None:
             "pip install -e . --no-build-isolation",
             "Run this command to install NssMPClib (CPU path):",
         )
-        preferred = preferred_nvcc(nvccs)
-        cuda_index = (
-            torch_index(preferred.release)
-            if preferred and preferred.release
-            else "https://download.pytorch.org/whl/cu128"
-        )
-        print()
-        print("If you would rather use the GPU, install a CUDA torch wheel first, then rerun this script:")
-        print_command(
-            f"pip install torch torchvision torchaudio --index-url {cuda_index}",
-            "Optional CUDA torch install:",
-        )
+        compute_caps = nvidia_smi_compute_caps()
+        if not all_compute_caps_too_old(compute_caps):
+            driver_cuda = nvidia_smi_driver_cuda()
+            picked = recommended_cuda_torch_index(nvccs, driver_cuda)
+            if picked:
+                cu_version, cu_url = picked
+                label = f"cu{cu_version.replace('.', '')}"
+                print()
+                print(
+                    f"If you would rather use the GPU, install CUDA torch ({label}) first, "
+                    "then rerun this script:"
+                )
+                print_command(
+                    f"pip install torch torchvision torchaudio --index-url {cu_url}",
+                    f"Optional CUDA torch install ({label}):",
+                )
         return
 
     print("CPU-only environment detected; setup.py will auto-skip the CUDA extensions.")
@@ -401,6 +609,12 @@ def main() -> int:
         if smi_output:
             for line in smi_output.splitlines():
                 print(f"  {line}")
+        driver_cuda = nvidia_smi_driver_cuda()
+        if driver_cuda:
+            print(f"driver-supported CUDA (max): {driver_cuda}")
+        caps = nvidia_smi_compute_caps()
+        if caps:
+            print("compute capability: " + ", ".join(caps))
     else:
         print("nvidia-smi: not found")
 
@@ -411,6 +625,17 @@ def main() -> int:
     else:
         print("cutlass: ok")
         print("csprng: ok")
+
+    print_section("Build dependencies")
+    for name in ("setuptools", "wheel"):
+        try:
+            mod = __import__(name)
+            version = getattr(mod, "__version__", "unknown")
+            print(f"{name}: {version}")
+        except ImportError:
+            print(f"{name}: missing")
+    has_compiler, _ = detect_cpp_compiler()
+    print(f"C/C++ compiler: {'found' if has_compiler else 'not found'}")
 
     recommend(root, torch_info, nvccs)
 

--- a/scripts/installation_advice.py
+++ b/scripts/installation_advice.py
@@ -326,31 +326,38 @@ def recommend(root: Path, torch_info: TorchInfo, nvccs: list[NvccInfo]) -> None:
 
     has_nvidia_smi, smi_output = detect_nvidia_smi()
     if has_nvidia_smi:
-        print("An NVIDIA driver appears to be present, but this PyTorch build is CPU-only.")
+        print("PyTorch is installed as a CPU-only build, though an NVIDIA driver is present.")
         if smi_output:
             print("Detected GPUs:")
             for line in smi_output.splitlines():
                 print(f"  {line}")
-        print("Install a CUDA-enabled PyTorch wheel first.")
+        print(
+            "setup.py and csprng/setup.py both auto-skip their CUDA extensions when "
+            "torch is CPU-only, so the standard install below works as-is for a CPU run."
+        )
+        print_command(
+            "pip install -e . --no-build-isolation",
+            "Run this command to install NssMPClib (CPU path):",
+        )
         preferred = preferred_nvcc(nvccs)
-        if preferred and preferred.release:
-            print(f"The newest detected local nvcc is CUDA {preferred.release} at {preferred.path}.")
-            print_command(
-                "pip install torch torchvision torchaudio "
-                f"--index-url {torch_index(preferred.release)}",
-                "Run this command to install a matching PyTorch build:",
-            )
-        else:
-            print_command(
-                "pip install torch torchvision torchaudio --index-url https://download.pytorch.org/whl/cu128",
-                "Run this command to install a CUDA PyTorch build:",
-            )
-        print("Then rerun: python3 scripts/installation_advice.py")
+        cuda_index = (
+            torch_index(preferred.release)
+            if preferred and preferred.release
+            else "https://download.pytorch.org/whl/cu128"
+        )
+        print()
+        print("If you would rather use the GPU, install a CUDA torch wheel first, then rerun this script:")
+        print_command(
+            f"pip install torch torchvision torchaudio --index-url {cuda_index}",
+            "Optional CUDA torch install:",
+        )
         return
 
-    print("No usable NVIDIA CUDA path was detected.")
-    print("Recommended standard install:")
-    print_command("NSSMPC_SKIP_CUTLASS=1 NSSMPC_SKIP_CSPRNG_CUDA=1 pip install -e . --no-build-isolation")
+    print("CPU-only environment detected; setup.py will auto-skip the CUDA extensions.")
+    print_command(
+        "pip install -e . --no-build-isolation",
+        "Run this command to install NssMPClib (CPU path):",
+    )
 
 
 def main() -> int:

--- a/scripts/installation_advice.py
+++ b/scripts/installation_advice.py
@@ -266,25 +266,12 @@ def recommend(root: Path, torch_info: TorchInfo, nvccs: list[NvccInfo]) -> None:
     if torch_info.cuda_version and torch_info.cuda_available:
         exact = matching_nvcc(torch_info.cuda_version, nvccs)
         if exact:
-            cuda_home = str(Path(exact.path).parents[1])
-            arch_list = []
-            for _, _, cap in torch_info.devices:
-                if cap not in arch_list:
-                    arch_list.append(cap)
-            archs = " ".join(arch_list)
             print("CUDA PyTorch and a matching nvcc were detected.")
-            print("Recommended CUDA-optimized install:")
-            if archs:
-                print_command(
-                    f"CUDA_HOME={cuda_home} TORCH_CUDA_ARCH_LIST='{archs}' "
-                    "pip install -e . --no-build-isolation",
-                    "Run this command to install NssMPClib with CUDA extensions:",
-                )
-            else:
-                print_command(
-                    f"CUDA_HOME={cuda_home} pip install -e . --no-build-isolation",
-                    "Run this command to install NssMPClib with CUDA extensions:",
-                )
+            print("setup.py will auto-detect CUDA_HOME and TORCH_CUDA_ARCH_LIST.")
+            print_command(
+                "pip install -e . --no-build-isolation",
+                "Run this command to install NssMPClib with CUDA extensions:",
+            )
             return
 
         major_match = major_matching_nvcc(torch_info.cuda_version, nvccs)

--- a/scripts/installation_advice.py
+++ b/scripts/installation_advice.py
@@ -1,0 +1,428 @@
+#!/usr/bin/env python3
+"""Recommend an installation path for the current machine.
+
+This script is intentionally read-only: it diagnoses Python, PyTorch, CUDA,
+nvcc, GPU architecture, and submodule state, then prints the installation
+commands that are most likely to work.
+"""
+
+from __future__ import annotations
+
+import glob
+import os
+import platform
+import re
+import shutil
+import subprocess
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterable
+
+
+YES_VALUES = {"1", "true", "yes", "on"}
+
+
+@dataclass(frozen=True)
+class NvccInfo:
+    path: str
+    release: str | None
+
+
+@dataclass(frozen=True)
+class TorchInfo:
+    installed: bool
+    version: str | None = None
+    cuda_version: str | None = None
+    cuda_available: bool = False
+    devices: tuple[tuple[int, str, str], ...] = ()
+    error: str | None = None
+
+
+def run_cmd(args: list[str], timeout: int = 5) -> tuple[int, str]:
+    try:
+        proc = subprocess.run(
+            args,
+            check=False,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            text=True,
+            timeout=timeout,
+        )
+    except (OSError, subprocess.SubprocessError) as exc:
+        return 1, str(exc)
+    return proc.returncode, proc.stdout.strip()
+
+
+def repo_root() -> Path:
+    return Path(__file__).resolve().parents[1]
+
+
+def env_enabled(name: str) -> bool:
+    return os.environ.get(name, "").strip().lower() in YES_VALUES
+
+
+def detect_torch() -> TorchInfo:
+    try:
+        import torch  # type: ignore
+    except Exception as exc:
+        return TorchInfo(installed=False, error=str(exc))
+
+    devices: list[tuple[int, str, str]] = []
+    cuda_available = False
+    try:
+        cuda_available = bool(torch.cuda.is_available())
+        if cuda_available:
+            for idx in range(torch.cuda.device_count()):
+                major, minor = torch.cuda.get_device_capability(idx)
+                devices.append((idx, torch.cuda.get_device_name(idx), f"{major}.{minor}"))
+    except Exception as exc:
+        return TorchInfo(
+            installed=True,
+            version=getattr(torch, "__version__", None),
+            cuda_version=getattr(torch.version, "cuda", None),
+            cuda_available=False,
+            devices=tuple(devices),
+            error=f"torch CUDA probe failed: {exc}",
+        )
+
+    return TorchInfo(
+        installed=True,
+        version=getattr(torch, "__version__", None),
+        cuda_version=getattr(torch.version, "cuda", None),
+        cuda_available=cuda_available,
+        devices=tuple(devices),
+    )
+
+
+def nvcc_release(nvcc_path: str) -> str | None:
+    code, out = run_cmd([nvcc_path, "--version"])
+    if code != 0:
+        return None
+    match = re.search(r"release\s+(\d+\.\d+)", out)
+    return match.group(1) if match else None
+
+
+def unique_paths(paths: Iterable[str]) -> list[str]:
+    seen: set[str] = set()
+    result: list[str] = []
+    for path in paths:
+        if not path or path in seen:
+            continue
+        seen.add(path)
+        result.append(path)
+    return result
+
+
+def detect_nvccs() -> list[NvccInfo]:
+    candidates: list[str] = []
+
+    cuda_home = os.environ.get("CUDA_HOME")
+    if cuda_home:
+        candidates.append(str(Path(cuda_home) / "bin" / "nvcc"))
+
+    path_nvcc = shutil.which("nvcc")
+    if path_nvcc:
+        candidates.append(path_nvcc)
+
+    candidates.append("/usr/local/cuda/bin/nvcc")
+    candidates.extend(sorted(glob.glob("/usr/local/cuda-*/bin/nvcc"), reverse=True))
+
+    infos = []
+    for path in unique_paths(candidates):
+        if Path(path).is_file():
+            infos.append(NvccInfo(path=path, release=nvcc_release(path)))
+    return infos
+
+
+def detect_nvidia_smi() -> tuple[bool, str | None]:
+    smi = shutil.which("nvidia-smi")
+    if not smi:
+        return False, None
+    code, out = run_cmd([smi, "-L"])
+    if code != 0 or not out:
+        return True, None
+    return True, out
+
+
+def ubuntu_codename() -> str | None:
+    os_release = Path("/etc/os-release")
+    if not os_release.exists():
+        return None
+    data: dict[str, str] = {}
+    for line in os_release.read_text(errors="ignore").splitlines():
+        if "=" not in line or line.startswith("#"):
+            continue
+        key, value = line.split("=", 1)
+        data[key] = value.strip().strip('"')
+    if data.get("ID", "").lower() != "ubuntu":
+        return None
+    version = data.get("VERSION_ID", "").replace(".", "")
+    return f"ubuntu{version}" if version else None
+
+
+def cuda_apt_package(cuda_version: str) -> str:
+    return f"cuda-toolkit-{cuda_version.replace('.', '-')}"
+
+
+def torch_index(cuda_version: str) -> str:
+    return f"https://download.pytorch.org/whl/cu{cuda_version.replace('.', '')}"
+
+
+def matching_nvcc(torch_cuda: str | None, nvccs: list[NvccInfo]) -> NvccInfo | None:
+    if not torch_cuda:
+        return None
+    for info in nvccs:
+        if info.release == torch_cuda:
+            return info
+    return None
+
+
+def major_matching_nvcc(torch_cuda: str | None, nvccs: list[NvccInfo]) -> NvccInfo | None:
+    if not torch_cuda:
+        return None
+    major = torch_cuda.split(".", 1)[0]
+    for info in nvccs:
+        if info.release and info.release.split(".", 1)[0] == major:
+            return info
+    return None
+
+
+def preferred_nvcc(nvccs: list[NvccInfo]) -> NvccInfo | None:
+    versioned = [info for info in nvccs if info.release]
+    if not versioned:
+        return nvccs[0] if nvccs else None
+
+    def key(info: NvccInfo) -> tuple[int, int]:
+        major, _, minor = (info.release or "0.0").partition(".")
+        return int(major or 0), int(minor or 0)
+
+    return max(versioned, key=key)
+
+
+def submodule_status(root: Path) -> list[str]:
+    missing = []
+    if not (root / "cutlass" / "include" / "cutlass" / "cutlass.h").exists():
+        missing.append("cutlass")
+    if not (root / "csprng" / "setup.py").exists():
+        missing.append("csprng")
+    return missing
+
+
+def print_section(title: str) -> None:
+    print(f"\n{title}")
+    print("-" * len(title))
+
+
+def print_command(command: str, intro: str = "Run this command:") -> None:
+    print(intro)
+    print()
+    print(command)
+
+
+def recommend(root: Path, torch_info: TorchInfo, nvccs: list[NvccInfo]) -> None:
+    missing_submodules = submodule_status(root)
+    skip_cutlass = env_enabled("NSSMPC_SKIP_CUTLASS")
+    skip_csprng_cuda = env_enabled("NSSMPC_SKIP_CSPRNG_CUDA")
+
+    print_section("Recommendation")
+
+    if missing_submodules:
+        print("Submodules are missing, so installation should start here:")
+        print_command("git submodule update --init --recursive")
+        print("Then rerun: python3 scripts/installation_advice.py")
+        return
+
+    if skip_cutlass or skip_csprng_cuda:
+        print("Skip flags are already set in the environment.")
+        if skip_cutlass:
+            print("  NSSMPC_SKIP_CUTLASS is enabled.")
+        if skip_csprng_cuda:
+            print("  NSSMPC_SKIP_CSPRNG_CUDA is enabled.")
+        print("Recommended standard install:")
+        print_command("NSSMPC_SKIP_CUTLASS=1 NSSMPC_SKIP_CSPRNG_CUDA=1 pip install -e . --no-build-isolation")
+        return
+
+    if not torch_info.installed:
+        print("PyTorch is not installed, so CUDA capability cannot be evaluated yet.")
+        print("Install a PyTorch build that matches your GPU/driver first.")
+        preferred = preferred_nvcc(nvccs)
+        if preferred and preferred.release:
+            print(f"The newest detected local nvcc is CUDA {preferred.release} at {preferred.path}.")
+            print_command(
+                "pip install torch torchvision torchaudio "
+                f"--index-url {torch_index(preferred.release)}",
+                "Run this command to install a matching PyTorch build:",
+            )
+        else:
+            print_command(
+                "pip install torch torchvision torchaudio --index-url https://download.pytorch.org/whl/cu128",
+                "Run this command to install a CUDA PyTorch build:",
+            )
+        print("Then rerun: python3 scripts/installation_advice.py")
+        print("If your machine is CPU-only, use the standard install after installing CPU PyTorch.")
+        return
+
+    if torch_info.cuda_version and torch_info.cuda_available:
+        exact = matching_nvcc(torch_info.cuda_version, nvccs)
+        if exact:
+            cuda_home = str(Path(exact.path).parents[1])
+            arch_list = []
+            for _, _, cap in torch_info.devices:
+                if cap not in arch_list:
+                    arch_list.append(cap)
+            archs = " ".join(arch_list)
+            print("CUDA PyTorch and a matching nvcc were detected.")
+            print("Recommended CUDA-optimized install:")
+            if archs:
+                print_command(
+                    f"CUDA_HOME={cuda_home} TORCH_CUDA_ARCH_LIST='{archs}' "
+                    "pip install -e . --no-build-isolation",
+                    "Run this command to install NssMPClib with CUDA extensions:",
+                )
+            else:
+                print_command(
+                    f"CUDA_HOME={cuda_home} pip install -e . --no-build-isolation",
+                    "Run this command to install NssMPClib with CUDA extensions:",
+                )
+            return
+
+        major_match = major_matching_nvcc(torch_info.cuda_version, nvccs)
+        if major_match:
+            print(
+                f"PyTorch was built for CUDA {torch_info.cuda_version}, but the closest nvcc "
+                f"is {major_match.release} at {major_match.path}."
+            )
+        else:
+            print(f"PyTorch was built for CUDA {torch_info.cuda_version}, but no matching nvcc was found.")
+
+        print(
+            "Install the CUDA Toolkit / nvcc version that matches torch.version.cuda, "
+            "then rerun the installation advice script."
+        )
+
+        codename = ubuntu_codename()
+        if codename:
+            print("Ubuntu apt example:")
+            print_command(
+                "wget https://developer.download.nvidia.com/compute/cuda/repos/"
+                f"{codename}/x86_64/cuda-keyring_1.1-1_all.deb\n"
+                "sudo dpkg -i cuda-keyring_1.1-1_all.deb\n"
+                "sudo apt-get update\n"
+                f"sudo apt-get install -y {cuda_apt_package(torch_info.cuda_version)}\n"
+                f"export CUDA_HOME=/usr/local/cuda-{torch_info.cuda_version}",
+                "Run these commands to install the matching CUDA Toolkit on Ubuntu:",
+            )
+        else:
+            print("CUDA Toolkit download page:")
+            print_command(
+                f"https://developer.nvidia.com/cuda-{torch_info.cuda_version}-0-download-archive",
+                "Open this page and install the matching CUDA Toolkit:",
+            )
+
+        print("If you prefer matching PyTorch to an existing toolkit instead, reinstall torch with:")
+        print_command(
+            f"pip install torch torchvision torchaudio --index-url {torch_index(torch_info.cuda_version)}",
+            "Alternative command:",
+        )
+        print("After fixing the toolkit or PyTorch version, rerun: python3 scripts/installation_advice.py")
+        return
+
+    if torch_info.cuda_version and not torch_info.cuda_available:
+        print(
+            f"PyTorch was built with CUDA {torch_info.cuda_version}, but torch.cuda.is_available() is false."
+        )
+        print("Check the NVIDIA driver, container GPU passthrough, or CUDA_VISIBLE_DEVICES first.")
+        print("For a non-GPU install, use:")
+        print_command("NSSMPC_SKIP_CUTLASS=1 NSSMPC_SKIP_CSPRNG_CUDA=1 pip install -e . --no-build-isolation")
+        return
+
+    has_nvidia_smi, smi_output = detect_nvidia_smi()
+    if has_nvidia_smi:
+        print("An NVIDIA driver appears to be present, but this PyTorch build is CPU-only.")
+        if smi_output:
+            print("Detected GPUs:")
+            for line in smi_output.splitlines():
+                print(f"  {line}")
+        print("Install a CUDA-enabled PyTorch wheel first.")
+        preferred = preferred_nvcc(nvccs)
+        if preferred and preferred.release:
+            print(f"The newest detected local nvcc is CUDA {preferred.release} at {preferred.path}.")
+            print_command(
+                "pip install torch torchvision torchaudio "
+                f"--index-url {torch_index(preferred.release)}",
+                "Run this command to install a matching PyTorch build:",
+            )
+        else:
+            print_command(
+                "pip install torch torchvision torchaudio --index-url https://download.pytorch.org/whl/cu128",
+                "Run this command to install a CUDA PyTorch build:",
+            )
+        print("Then rerun: python3 scripts/installation_advice.py")
+        return
+
+    print("No usable NVIDIA CUDA path was detected.")
+    print("Recommended standard install:")
+    print_command("NSSMPC_SKIP_CUTLASS=1 NSSMPC_SKIP_CSPRNG_CUDA=1 pip install -e . --no-build-isolation")
+
+
+def main() -> int:
+    root = repo_root()
+    torch_info = detect_torch()
+    nvccs = detect_nvccs()
+    has_nvidia_smi, smi_output = detect_nvidia_smi()
+
+    print("NssMPClib installation advice")
+    print(f"Repository: {root}")
+
+    print_section("Environment")
+    print(f"Python: {platform.python_version()} ({sys.executable})")
+    print(f"Platform: {platform.platform()}")
+    print(f"CUDA_HOME: {os.environ.get('CUDA_HOME') or '<unset>'}")
+    print(f"TORCH_CUDA_ARCH_LIST: {os.environ.get('TORCH_CUDA_ARCH_LIST') or '<unset>'}")
+
+    print_section("PyTorch")
+    if torch_info.installed:
+        print(f"torch: {torch_info.version}")
+        print(f"torch.version.cuda: {torch_info.cuda_version or '<cpu-only>'}")
+        print(f"torch.cuda.is_available(): {torch_info.cuda_available}")
+        if torch_info.devices:
+            for idx, name, cap in torch_info.devices:
+                print(f"GPU {idx}: {name} (sm_{cap.replace('.', '')})")
+        if torch_info.error:
+            print(f"warning: {torch_info.error}")
+    else:
+        print("torch: not installed")
+        if torch_info.error:
+            print(f"import error: {torch_info.error}")
+
+    print_section("CUDA Toolchain")
+    if nvccs:
+        for info in nvccs:
+            print(f"nvcc: {info.path} (release {info.release or 'unknown'})")
+    else:
+        print("nvcc: not found")
+    if has_nvidia_smi:
+        print("nvidia-smi: found")
+        if smi_output:
+            for line in smi_output.splitlines():
+                print(f"  {line}")
+    else:
+        print("nvidia-smi: not found")
+
+    print_section("Submodules")
+    missing = submodule_status(root)
+    if missing:
+        print("missing: " + ", ".join(missing))
+    else:
+        print("cutlass: ok")
+        print("csprng: ok")
+
+    recommend(root, torch_info, nvccs)
+
+    print("\nNote: this script only recommends commands; it does not install anything.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/installation_advice.py
+++ b/scripts/installation_advice.py
@@ -1,18 +1,25 @@
 #!/usr/bin/env python3
-"""Recommend an installation path for the current machine.
+"""Diagnose whether the current machine is ready to install NssMPClib.
 
-This script is intentionally read-only: it diagnoses Python, PyTorch, CUDA,
-nvcc, GPU architecture, and submodule state, then prints the installation
-commands that are most likely to work.
+This script is intentionally read-only. It checks Python, PyTorch, CUDA,
+nvcc, GPU architecture, submodule state, Python build dependencies, and a
+C/C++ compiler.
+
+It does NOT print installation commands. Instead, it reports PASS/WARN/FAIL
+with the reason and expected condition, so users can decide how to fix their
+own environment.
 """
 
 from __future__ import annotations
 
 import glob
+import importlib.metadata
 import os
 import platform
 import re
+import shlex
 import shutil
+import site
 import subprocess
 import sys
 from dataclasses import dataclass
@@ -22,13 +29,18 @@ from typing import Iterable
 
 YES_VALUES = {"1", "true", "yes", "on"}
 
-# CUDA versions for which PyTorch publishes a cu* wheel index.
-# Keep sorted ascending; recommendations always pick the highest entry that is
-# <= the driver-supported CUDA or local nvcc release.
+MIN_PYTHON_VERSION = (3, 10)
+RECOMMENDED_PYTHON_VERSION = "3.12"
+MIN_TORCH_VERSION = (2, 5, 0)
+RECOMMENDED_TORCH_VERSION = "2.7.1"
+MIN_SETUPTOOLS_VERSION = (64,)
+
+# CUDA versions for which PyTorch commonly publishes cu* wheel indexes.
+# This is kept for diagnosis only; the script does not generate install commands.
 PYTORCH_CUDA_INDEXES = ("11.8", "12.1", "12.4", "12.6", "12.8")
 
-# Minimum CUDA compute capability supported by modern PyTorch wheels (sm_50).
-# Cards below this (Kepler sm_3.x and earlier) cannot run cu* wheels.
+# Minimum CUDA compute capability supported by modern PyTorch CUDA wheels.
+# Cards below this, for example Kepler sm_3.x, cannot run recent cu* wheels.
 MIN_PYTORCH_COMPUTE_CAP = (5, 0)
 
 
@@ -71,6 +83,51 @@ def env_enabled(name: str) -> bool:
     return os.environ.get(name, "").strip().lower() in YES_VALUES
 
 
+def version_text(version: tuple[int, ...]) -> str:
+    return ".".join(str(part) for part in version)
+
+
+def _parse_numeric_version(value: str | None) -> tuple[int, ...] | None:
+    if not value:
+        return None
+
+    match = re.match(r"^\s*(\d+(?:\.\d+)*)", value)
+    if not match:
+        return None
+
+    return tuple(int(part) for part in match.group(1).split("."))
+
+
+def version_at_least(value: str | None, minimum: tuple[int, ...]) -> bool:
+    parsed = _parse_numeric_version(value)
+    if not parsed:
+        return False
+
+    size = max(len(parsed), len(minimum))
+    padded = parsed + (0,) * (size - len(parsed))
+    padded_minimum = minimum + (0,) * (size - len(minimum))
+    return padded >= padded_minimum
+
+
+def version_less_than(value: str | None, maximum: tuple[int, ...]) -> bool:
+    parsed = _parse_numeric_version(value)
+    if not parsed:
+        return False
+
+    size = max(len(parsed), len(maximum))
+    padded = parsed + (0,) * (size - len(parsed))
+    padded_maximum = maximum + (0,) * (size - len(maximum))
+    return padded < padded_maximum
+
+
+def cuda_label(cuda_version: str) -> str:
+    return "cu" + cuda_version.replace(".", "")
+
+
+def known_cuda_labels() -> str:
+    return ", ".join(cuda_label(version) for version in PYTORCH_CUDA_INDEXES)
+
+
 def detect_torch() -> TorchInfo:
     try:
         import torch  # type: ignore
@@ -79,6 +136,7 @@ def detect_torch() -> TorchInfo:
 
     devices: list[tuple[int, str, str]] = []
     cuda_available = False
+
     try:
         cuda_available = bool(torch.cuda.is_available())
         if cuda_available:
@@ -108,6 +166,7 @@ def nvcc_release(nvcc_path: str) -> str | None:
     code, out = run_cmd([nvcc_path, "--version"])
     if code != 0:
         return None
+
     match = re.search(r"release\s+(\d+\.\d+)", out)
     return match.group(1) if match else None
 
@@ -115,159 +174,202 @@ def nvcc_release(nvcc_path: str) -> str | None:
 def unique_paths(paths: Iterable[str]) -> list[str]:
     seen: set[str] = set()
     result: list[str] = []
+
     for path in paths:
         if not path or path in seen:
             continue
         seen.add(path)
         result.append(path)
+
     return result
+
+
+def unique_existing_dirs(paths: Iterable[str]) -> list[str]:
+    result: list[str] = []
+
+    for path in unique_paths(paths):
+        if Path(path).is_dir():
+            result.append(path)
+
+    return result
+
+
+def cuda_home_candidates() -> list[str]:
+    candidates: list[str] = []
+
+    for env_name in ("CUDA_HOME", "CUDA_PATH", "CONDA_PREFIX"):
+        value = os.environ.get(env_name)
+        if value:
+            candidates.append(value)
+
+    path_nvcc = shutil.which("nvcc")
+    if path_nvcc:
+        candidates.append(str(Path(path_nvcc).parent.parent))
+
+    candidates.append("/usr/local/cuda")
+    candidates.extend(sorted(glob.glob("/usr/local/cuda-*"), reverse=True))
+
+    return unique_paths(str(Path(candidate).absolute()) for candidate in candidates if candidate)
 
 
 def detect_nvccs() -> list[NvccInfo]:
     candidates: list[str] = []
 
-    cuda_home = os.environ.get("CUDA_HOME")
-    if cuda_home:
+    for cuda_home in cuda_home_candidates():
         candidates.append(str(Path(cuda_home) / "bin" / "nvcc"))
 
-    path_nvcc = shutil.which("nvcc")
-    if path_nvcc:
-        candidates.append(path_nvcc)
-
-    candidates.append("/usr/local/cuda/bin/nvcc")
-    candidates.extend(sorted(glob.glob("/usr/local/cuda-*/bin/nvcc"), reverse=True))
-
-    infos = []
+    infos: list[NvccInfo] = []
     for path in unique_paths(candidates):
         if Path(path).is_file():
             infos.append(NvccInfo(path=path, release=nvcc_release(path)))
+
     return infos
+
+
+def python_site_dirs() -> list[str]:
+    dirs: list[str] = []
+
+    try:
+        dirs.extend(site.getsitepackages())
+    except Exception:
+        pass
+
+    try:
+        user_site = site.getusersitepackages()
+        if user_site:
+            dirs.append(user_site)
+    except Exception:
+        pass
+
+    conda_prefix = os.environ.get("CONDA_PREFIX")
+    if conda_prefix:
+        dirs.extend(glob.glob(str(Path(conda_prefix) / "lib" / "python*" / "site-packages")))
+
+    return unique_existing_dirs(dirs)
+
+
+def cuda_include_dirs() -> list[str]:
+    candidates: list[str] = []
+
+    for root in cuda_home_candidates():
+        candidates.append(str(Path(root) / "include"))
+        candidates.append(str(Path(root) / "targets" / "x86_64-linux" / "include"))
+
+    for site_dir in python_site_dirs():
+        candidates.extend(glob.glob(str(Path(site_dir) / "nvidia" / "*" / "include")))
+
+    return unique_existing_dirs(candidates)
+
+
+def missing_cuda_headers() -> tuple[list[str], list[str]]:
+    include_dirs = cuda_include_dirs()
+    missing: list[str] = []
+
+    for header in ("cuda_runtime.h", "cublas_v2.h"):
+        if not any((Path(include_dir) / header).exists() for include_dir in include_dirs):
+            missing.append(header)
+
+    return missing, include_dirs
 
 
 def detect_nvidia_smi() -> tuple[bool, str | None]:
     smi = shutil.which("nvidia-smi")
     if not smi:
         return False, None
+
     code, out = run_cmd([smi, "-L"])
     if code != 0 or not out:
         return True, None
+
     return True, out
 
 
 def _parse_version(value: str | None) -> tuple[int, int] | None:
     if not value:
         return None
+
     m = re.match(r"^\s*(\d+)\.(\d+)", value)
     return (int(m.group(1)), int(m.group(2))) if m else None
 
 
 def nvidia_smi_driver_cuda() -> str | None:
-    """Max CUDA version the NVIDIA driver supports, parsed from `nvidia-smi` header."""
+    """Return max CUDA version supported by the NVIDIA driver, parsed from nvidia-smi."""
     smi = shutil.which("nvidia-smi")
     if not smi:
         return None
+
     code, out = run_cmd([smi])
     if code != 0:
         return None
+
     m = re.search(r"CUDA Version:\s*([\d.]+)", out)
     return m.group(1) if m else None
 
 
 def nvidia_smi_compute_caps() -> list[str]:
-    """Per-GPU compute capability strings from `nvidia-smi --query-gpu=compute_cap`."""
+    """Return per-GPU compute capability strings from nvidia-smi."""
     smi = shutil.which("nvidia-smi")
     if not smi:
         return []
+
     code, out = run_cmd([smi, "--query-gpu=compute_cap", "--format=csv,noheader,nounits"])
     if code != 0:
         return []
+
     return [line.strip() for line in out.splitlines() if line.strip()]
 
 
 def pytorch_cu_index_for(cuda_version: str | None) -> str | None:
-    """Highest entry in PYTORCH_CUDA_INDEXES that is <= cuda_version."""
+    """Return the highest known PyTorch CUDA index <= cuda_version.
+
+    Used only for diagnosis text. This script does not generate pip commands.
+    """
     target = _parse_version(cuda_version)
     if not target:
         return None
+
     best: tuple[int, int] | None = None
     best_str: str | None = None
-    for v in PYTORCH_CUDA_INDEXES:
-        parsed = _parse_version(v)
+
+    for version in PYTORCH_CUDA_INDEXES:
+        parsed = _parse_version(version)
         if parsed and parsed <= target and (best is None or parsed > best):
             best = parsed
-            best_str = v
+            best_str = version
+
     return best_str
-
-
-def recommended_cuda_torch_index(
-    nvccs: list[NvccInfo], driver_cuda: str | None
-) -> tuple[str, str] | None:
-    """Pick the best (cuda_version, wheel_index_url) for installing PyTorch.
-
-    Prefers a wheel matching a local nvcc release (so the user can also build
-    NssMPClib's CUDA extensions with that nvcc), then falls back to the
-    driver-supported max CUDA. Returns None when nothing in
-    PYTORCH_CUDA_INDEXES fits.
-    """
-    preferred = preferred_nvcc(nvccs)
-    if preferred and preferred.release:
-        picked = pytorch_cu_index_for(preferred.release)
-        if picked:
-            return picked, torch_index(picked)
-    picked = pytorch_cu_index_for(driver_cuda)
-    if picked:
-        return picked, torch_index(picked)
-    return None
 
 
 def all_compute_caps_too_old(caps: Iterable[str]) -> bool:
     """True iff at least one cap was reported and the max is below MIN_PYTORCH_COMPUTE_CAP."""
-    parsed = [p for p in (_parse_version(c) for c in caps) if p]
+    parsed = [p for p in (_parse_version(cap) for cap in caps) if p]
     if not parsed:
         return False
+
     return max(parsed) < MIN_PYTORCH_COMPUTE_CAP
-
-
-def ubuntu_codename() -> str | None:
-    os_release = Path("/etc/os-release")
-    if not os_release.exists():
-        return None
-    data: dict[str, str] = {}
-    for line in os_release.read_text(errors="ignore").splitlines():
-        if "=" not in line or line.startswith("#"):
-            continue
-        key, value = line.split("=", 1)
-        data[key] = value.strip().strip('"')
-    if data.get("ID", "").lower() != "ubuntu":
-        return None
-    version = data.get("VERSION_ID", "").replace(".", "")
-    return f"ubuntu{version}" if version else None
-
-
-def cuda_apt_package(cuda_version: str) -> str:
-    return f"cuda-toolkit-{cuda_version.replace('.', '-')}"
-
-
-def torch_index(cuda_version: str) -> str:
-    return f"https://download.pytorch.org/whl/cu{cuda_version.replace('.', '')}"
 
 
 def matching_nvcc(torch_cuda: str | None, nvccs: list[NvccInfo]) -> NvccInfo | None:
     if not torch_cuda:
         return None
+
     for info in nvccs:
         if info.release == torch_cuda:
             return info
+
     return None
 
 
 def major_matching_nvcc(torch_cuda: str | None, nvccs: list[NvccInfo]) -> NvccInfo | None:
     if not torch_cuda:
         return None
+
     major = torch_cuda.split(".", 1)[0]
+
     for info in nvccs:
         if info.release and info.release.split(".", 1)[0] == major:
             return info
+
     return None
 
 
@@ -284,62 +386,175 @@ def preferred_nvcc(nvccs: list[NvccInfo]) -> NvccInfo | None:
 
 
 def submodule_status(root: Path) -> list[str]:
-    missing = []
+    missing: list[str] = []
+
     if not (root / "cutlass" / "include" / "cutlass" / "cutlass.h").exists():
         missing.append("cutlass")
+
     if not (root / "csprng" / "setup.py").exists():
         missing.append("csprng")
+
     return missing
 
 
 def detect_missing_build_deps() -> list[str]:
-    """Return missing names from ('setuptools', 'wheel') that --no-build-isolation needs."""
-    missing = []
-    for name in ("setuptools", "wheel"):
-        try:
-            __import__(name)
-        except ImportError:
-            missing.append(name)
-    return missing
+    """Return missing or too-old Python build dependencies."""
+    issues: list[str] = []
+
+    setuptools_version = package_version("setuptools")
+    if setuptools_version is None:
+        issues.append(f"setuptools missing (required >= {version_text(MIN_SETUPTOOLS_VERSION)})")
+    elif not version_at_least(setuptools_version, MIN_SETUPTOOLS_VERSION):
+        issues.append(
+            f"setuptools {setuptools_version} "
+            f"(required >= {version_text(MIN_SETUPTOOLS_VERSION)})"
+        )
+
+    wheel_version = package_version("wheel")
+    if wheel_version is None:
+        issues.append("wheel missing (required: installed)")
+
+    return issues
+
+
+def package_version(name: str) -> str | None:
+    try:
+        mod = __import__(name)
+    except ImportError:
+        return None
+
+    version = getattr(mod, "__version__", None)
+    if version:
+        return str(version)
+
+    try:
+        return importlib.metadata.version(name)
+    except importlib.metadata.PackageNotFoundError:
+        return "unknown"
 
 
 def detect_cpp_compiler() -> tuple[bool, str | None]:
-    """Best-effort detection of a C/C++ compiler that PyTorch can use for extension builds.
-
-    Returns (has_compiler, advice_message). torchcsprng always builds a native
-    extension, so this is required regardless of CUDA path.
-    """
+    """Best-effort detection of a C/C++ compiler usable for extension builds."""
     if platform.system() == "Windows":
         if shutil.which("cl"):
             return True, None
-        # Look for an actual cl.exe inside common VS / Build Tools layouts —
-        # directory existence alone isn't enough (installer leaves empty stubs).
+
         cl_patterns = [
             r"C:\Program Files\Microsoft Visual Studio\*\*\VC\Tools\MSVC\*\bin\Host*\*\cl.exe",
             r"C:\Program Files (x86)\Microsoft Visual Studio\*\*\VC\Tools\MSVC\*\bin\Host*\*\cl.exe",
             r"C:\BuildTools\VC\Tools\MSVC\*\bin\Host*\*\cl.exe",
         ]
-        if any(glob.glob(p) for p in cl_patterns):
+
+        if any(glob.glob(pattern) for pattern in cl_patterns):
             return False, (
-                "Microsoft Visual C++ appears to be installed but 'cl' is not on PATH. "
-                "Open the 'x64 Native Tools Command Prompt for VS' (or run vcvarsall.bat) "
-                "before retrying, so that the compiler is reachable."
+                "Microsoft Visual C++ appears to be installed, but 'cl' is not on PATH. "
+                "Open a Visual Studio Native Tools shell or initialize the compiler "
+                "environment before retrying."
             )
+
         return False, (
-            "Building torchcsprng's C++ extension requires Microsoft Visual C++ 14.0 or newer. "
-            "Install 'Build Tools for Visual Studio' (free) from "
-            "https://visualstudio.microsoft.com/visual-cpp-build-tools/ "
-            "with the 'Desktop development with C++' workload, then open the "
-            "'x64 Native Tools Command Prompt for VS' (so 'cl' is on PATH) before retrying."
+            "Building native extensions requires Microsoft Visual C++ 14.0 or newer."
         )
-    # Unix-like
+
     for name in ("c++", "g++", "clang++", "cc", "gcc", "clang"):
         if shutil.which(name):
             return True, None
+
     return False, (
-        "Building C/C++ extensions requires a system C++ compiler (gcc/g++ or clang). "
-        "On Ubuntu/Debian: sudo apt-get install build-essential."
+        "Building native extensions requires a system C/C++ compiler such as gcc/g++ or clang."
     )
+
+
+def cxx_compiler_command() -> list[str] | None:
+    env_cxx = os.environ.get("CXX")
+    if env_cxx:
+        return shlex.split(env_cxx)
+
+    if platform.system() == "Windows":
+        return ["cl"] if shutil.which("cl") else None
+
+    for name in ("g++", "c++", "clang++"):
+        if shutil.which(name):
+            return [name]
+
+    return None
+
+
+def compiler_version(command: list[str]) -> str | None:
+    for args in (command + ["-dumpfullversion", "-dumpversion"], command + ["--version"]):
+        code, out = run_cmd(args)
+        if code != 0:
+            continue
+
+        parsed = _parse_numeric_version(out)
+        if parsed:
+            return version_text(parsed)
+
+    return None
+
+
+def compiler_kind(command: list[str]) -> str:
+    name = Path(command[0]).name.lower()
+    if "clang" in name:
+        return "clang"
+    return "gcc"
+
+
+def cuda_compiler_bounds(torch_cuda: str, kind: str) -> tuple[tuple[int, ...], tuple[int, ...]] | None:
+    try:
+        from torch.utils import cpp_extension  # type: ignore
+    except Exception:
+        return None
+
+    bounds_map = (
+        getattr(cpp_extension, "CUDA_CLANG_VERSIONS", {})
+        if kind == "clang"
+        else getattr(cpp_extension, "CUDA_GCC_VERSIONS", {})
+    )
+    bounds = bounds_map.get(torch_cuda)
+    if not bounds:
+        return None
+
+    return tuple(bounds[0]), tuple(bounds[1])
+
+
+def detect_cuda_compiler_issue(torch_cuda: str | None) -> str | None:
+    if not torch_cuda or platform.system() != "Linux":
+        return None
+
+    if os.environ.get("TORCH_DONT_CHECK_COMPILER_ABI", "").upper() in {
+        "ON",
+        "1",
+        "YES",
+        "TRUE",
+        "Y",
+    }:
+        return None
+
+    command = cxx_compiler_command()
+    if not command:
+        return "No C++ compiler command was found for CUDA extension builds."
+
+    version = compiler_version(command)
+    if not version:
+        return f"Could not determine C++ compiler version for {' '.join(command)}."
+
+    kind = compiler_kind(command)
+    bounds = cuda_compiler_bounds(torch_cuda, kind)
+    if not bounds:
+        return None
+
+    min_version, max_exclusive_version = bounds
+    if not version_at_least(version, min_version) or not version_less_than(version, max_exclusive_version):
+        compiler_name = "clang++" if kind == "clang" else "g++"
+        return (
+            f"Detected {compiler_name}-compatible compiler {' '.join(command)} {version}, "
+            f"but CUDA {torch_cuda} requires {compiler_name} "
+            f">= {version_text(min_version)}, < {version_text(max_exclusive_version)} "
+            "for PyTorch CUDA extension builds."
+        )
+
+    return None
 
 
 def print_section(title: str) -> None:
@@ -347,225 +562,398 @@ def print_section(title: str) -> None:
     print("-" * len(title))
 
 
-def print_command(command: str, intro: str = "Run this command:") -> None:
-    print(intro)
-    print()
-    print(command)
+def print_status(status: str, message: str) -> None:
+    print(f"{status}: {message}")
 
 
-def recommend(root: Path, torch_info: TorchInfo, nvccs: list[NvccInfo]) -> None:
+def print_kv(key: str, value: str | None) -> None:
+    print(f"{key}: {value if value else '<unknown>'}")
+
+
+def print_required_versions(torch_info: TorchInfo, nvccs: list[NvccInfo]) -> None:
+    print_section("Required versions")
+    print(
+        f"Python: >= {version_text(MIN_PYTHON_VERSION)} "
+        f"(recommended {RECOMMENDED_PYTHON_VERSION})"
+    )
+    print(
+        f"PyTorch: >= {version_text(MIN_TORCH_VERSION)} "
+        f"(recommended {RECOMMENDED_TORCH_VERSION} or newer compatible release)"
+    )
+    print(f"Build backend: setuptools >= {version_text(MIN_SETUPTOOLS_VERSION)}, wheel installed")
+    print("Native compiler: gcc/g++ or clang on Linux; Microsoft Visual C++ 14.0+ on Windows")
+
+    if torch_info.cuda_version:
+        print(
+            "CUDA extension path: CUDA Toolkit / nvcc and development headers "
+            f"must match torch.version.cuda ({torch_info.cuda_version})."
+        )
+        driver_cuda = nvidia_smi_driver_cuda()
+        if driver_cuda:
+            print(
+                "NVIDIA driver: must support at least CUDA "
+                f"{torch_info.cuda_version}; detected driver max is {driver_cuda}."
+            )
+        return
+
+    has_smi, _ = detect_nvidia_smi()
+    if has_smi:
+        driver_cuda = nvidia_smi_driver_cuda()
+        picked = pytorch_cu_index_for(driver_cuda)
+        print("CPU path: CPU-only PyTorch is valid; CUDA Toolkit / nvcc is not required.")
+        print(
+            "GPU path: use a CUDA-enabled PyTorch build and a CUDA Toolkit / nvcc "
+            "with the same CUDA X.Y version."
+        )
+        if driver_cuda:
+            print(f"NVIDIA driver max CUDA: {driver_cuda}")
+        if picked:
+            print(f"Highest known PyTorch CUDA family fitting this driver: {cuda_label(picked)}")
+        print(f"Known PyTorch CUDA families in this checker: {known_cuda_labels()}")
+        return
+
+    print("CPU path: CPU-only PyTorch is valid; CUDA Toolkit / nvcc is not required.")
+
+
+def diagnose(root: Path, torch_info: TorchInfo, nvccs: list[NvccInfo]) -> int:
+    """Diagnose installation readiness.
+
+    Return codes:
+      0: PASS or acceptable WARN state
+      1: FAIL state requiring user action
+    """
     missing_submodules = submodule_status(root)
     missing_build_deps = detect_missing_build_deps()
     skip_cutlass = env_enabled("NSSMPC_SKIP_CUTLASS")
     skip_csprng_cuda = env_enabled("NSSMPC_SKIP_CSPRNG_CUDA")
+    force_cuda = env_enabled("FORCE_CUDA")
 
-    print_section("Recommendation")
+    print_section("Diagnosis")
+
+    if sys.version_info < MIN_PYTHON_VERSION:
+        print_status("FAIL", "Python is too old for NssMPClib.")
+        print_kv("current Python", platform.python_version())
+        print(
+            "Required: Python "
+            f"{version_text(MIN_PYTHON_VERSION)} or newer "
+            f"(recommended {RECOMMENDED_PYTHON_VERSION})."
+        )
+        return 1
 
     if missing_submodules:
-        print("Submodules are missing, so installation should start here:")
-        print_command("git submodule update --init --recursive")
-        print("Then rerun: python3 scripts/installation_advice.py")
-        return
+        print_status("FAIL", "Git submodules are missing.")
+        print("Missing: " + ", ".join(missing_submodules))
+        print("Reason: required source trees are not present in the repository.")
+        print(
+            "Required: the cutlass source tree must contain "
+            "cutlass/include/cutlass/cutlass.h, and the csprng source tree "
+            "must contain csprng/setup.py."
+        )
+        print("Expected: initialize or restore the missing submodules, then rerun this check.")
+        return 1
 
     if missing_build_deps:
+        print_status("FAIL", "Python build dependencies are missing.")
+        print("Missing/outdated: " + ", ".join(missing_build_deps))
+        print("Reason: editable builds with --no-build-isolation need these packages.")
         print(
-            "Build dependencies for --no-build-isolation are missing: "
-            + ", ".join(missing_build_deps)
-            + ". pip needs them to run the editable build and produce a wheel."
+            "Required: setuptools "
+            f">= {version_text(MIN_SETUPTOOLS_VERSION)} and wheel installed "
+            "in the same Python environment that will run pip."
         )
-        print_command(
-            "pip install --upgrade " + " ".join(missing_build_deps),
-            "Run this command to install them:",
-        )
-        print("Then rerun: python3 scripts/installation_advice.py")
-        return
+        print("Expected: make the required Python build packages available, then rerun this check.")
+        return 1
 
     has_compiler, compiler_advice = detect_cpp_compiler()
     if not has_compiler:
-        print(
-            "No C/C++ compiler was detected, but torchcsprng's native extension must "
-            "be compiled from source."
-        )
+        print_status("FAIL", "No usable C/C++ compiler was detected.")
+        print("Reason: native extensions must be compiled from source.")
         if compiler_advice:
-            print(compiler_advice)
-        print("Then rerun: python3 scripts/installation_advice.py")
-        return
-
-    if skip_cutlass or skip_csprng_cuda:
-        print("Skip flags are already set in the environment.")
-        if skip_cutlass:
-            print("  NSSMPC_SKIP_CUTLASS is enabled.")
-        if skip_csprng_cuda:
-            print("  NSSMPC_SKIP_CSPRNG_CUDA is enabled.")
-        print("Recommended standard install:")
-        print_command("NSSMPC_SKIP_CUTLASS=1 NSSMPC_SKIP_CSPRNG_CUDA=1 pip install -e . --no-build-isolation")
-        return
+            print("Details: " + compiler_advice)
+        print(
+            "Required: gcc/g++ or clang on Linux; Microsoft Visual C++ 14.0+ "
+            "with 'cl' on PATH on Windows."
+        )
+        print("Expected: make a C/C++ compiler available on PATH, then rerun this check.")
+        return 1
 
     if not torch_info.installed:
-        print("PyTorch is not installed, so CUDA capability cannot be evaluated yet.")
-        has_smi, _ = detect_nvidia_smi()
+        print_status("FAIL", "PyTorch is not installed.")
+        if torch_info.error:
+            print("Import error: " + torch_info.error)
+        print("Reason: CUDA availability and extension build compatibility cannot be evaluated.")
+        print(
+            "Required: PyTorch "
+            f">= {version_text(MIN_TORCH_VERSION)} "
+            f"(recommended {RECOMMENDED_TORCH_VERSION} or newer compatible release)."
+        )
+        preferred = preferred_nvcc(nvccs)
         driver_cuda = nvidia_smi_driver_cuda()
-        compute_caps = nvidia_smi_compute_caps()
-
-        if not has_smi and not nvccs:
-            print("No CUDA toolchain or NVIDIA driver detected; this looks like a CPU-only host.")
-            print_command(
-                "pip install torch torchvision torchaudio --index-url https://download.pytorch.org/whl/cpu",
-                "Run this command to install CPU PyTorch:",
-            )
-            print("Then rerun: python3 scripts/installation_advice.py")
-            return
-
-        if all_compute_caps_too_old(compute_caps):
-            cap_str = ", ".join(compute_caps) if compute_caps else "<unknown>"
-            min_cap = f"sm_{MIN_PYTORCH_COMPUTE_CAP[0]}{MIN_PYTORCH_COMPUTE_CAP[1]}"
+        target_cuda = preferred.release if preferred and preferred.release else driver_cuda
+        picked = pytorch_cu_index_for(target_cuda)
+        if preferred and preferred.release and picked:
             print(
-                f"NVIDIA driver detected, but GPU compute capability ({cap_str}) is below "
-                f"{min_cap}, which recent PyTorch CUDA wheels do not support."
+                "For GPU extension builds on this machine, prefer a CUDA PyTorch "
+                f"build with torch.version.cuda={picked} because nvcc {preferred.release} "
+                "was detected."
             )
-            print_command(
-                "pip install torch torchvision torchaudio --index-url https://download.pytorch.org/whl/cpu",
-                "Run this command to install CPU PyTorch instead:",
-            )
-            print("Then rerun: python3 scripts/installation_advice.py")
-            return
-
-        picked = recommended_cuda_torch_index(nvccs, driver_cuda)
-        if picked:
-            cu_version, cu_url = picked
-            label = f"cu{cu_version.replace('.', '')}"
-            context_parts = []
-            preferred = preferred_nvcc(nvccs)
-            if preferred and preferred.release:
-                context_parts.append(f"local nvcc {preferred.release}")
-            if driver_cuda:
-                context_parts.append(f"driver max CUDA {driver_cuda}")
-            context = "; ".join(context_parts) or "GPU present"
-            print(f"Choosing PyTorch {label} ({context}).")
-            print_command(
-                f"pip install torch torchvision torchaudio --index-url {cu_url}",
-                f"Run this command to install a CUDA PyTorch build ({label}):",
-            )
-            print("Then rerun: python3 scripts/installation_advice.py")
-            return
-
-        if driver_cuda:
+        elif driver_cuda and picked:
             print(
-                f"NVIDIA driver detected but max supported CUDA ({driver_cuda}) is below the "
-                f"lowest PyTorch CUDA wheel (cu{PYTORCH_CUDA_INDEXES[0].replace('.', '')}). "
-                "Update the NVIDIA driver, or install CPU PyTorch:"
+                "For GPU use on this machine, choose a CUDA PyTorch build no newer "
+                f"than driver-supported CUDA {driver_cuda}; the highest known family "
+                f"here is {cuda_label(picked)}."
             )
         else:
-            print(
-                "NVIDIA driver detected but its CUDA support could not be determined. "
-                "Falling back to CPU PyTorch:"
-            )
-        print_command(
-            "pip install torch torchvision torchaudio --index-url https://download.pytorch.org/whl/cpu",
-            "Run this command to install CPU PyTorch:",
+            print("For CPU-only use, install a CPU-only PyTorch build; CUDA Toolkit / nvcc is not required.")
+        print("Expected: provide a suitable PyTorch installation, then rerun this check.")
+        return 1
+
+    if torch_info.error:
+        print_status("FAIL", "PyTorch was imported, but CUDA probing failed.")
+        print("Details: " + torch_info.error)
+        print("Reason: the PyTorch/CUDA runtime is not healthy enough to evaluate safely.")
+        print("Expected: fix the PyTorch CUDA runtime error, then rerun this check.")
+        return 1
+
+    if not version_at_least(torch_info.version, MIN_TORCH_VERSION):
+        print_status("FAIL", "PyTorch is too old for NssMPClib.")
+        print_kv("current torch", torch_info.version)
+        print(
+            "Required: PyTorch "
+            f"{version_text(MIN_TORCH_VERSION)} or newer "
+            f"(recommended {RECOMMENDED_TORCH_VERSION} or newer compatible release)."
         )
-        print("Then rerun: python3 scripts/installation_advice.py")
-        return
+        print(
+            "Expected: keep the CPU/CUDA variant intentional; if using CUDA, "
+            "torch.version.cuda must match the CUDA Toolkit / nvcc release."
+        )
+        return 1
+
+    if skip_cutlass or skip_csprng_cuda:
+        if torch_info.cuda_version and not (skip_cutlass and skip_csprng_cuda):
+            print_status("FAIL", "CUDA extension skip flags are incomplete.")
+            if skip_cutlass:
+                print("  NSSMPC_SKIP_CUTLASS: enabled")
+            else:
+                print("  NSSMPC_SKIP_CUTLASS: not enabled")
+            if skip_csprng_cuda:
+                print("  NSSMPC_SKIP_CSPRNG_CUDA: enabled")
+            else:
+                print("  NSSMPC_SKIP_CSPRNG_CUDA: not enabled")
+            print(
+                "Reason: with a CUDA-enabled PyTorch build, the top-level CUTLASS "
+                "extension and bundled torchcsprng CUDA extension are controlled "
+                "by separate flags."
+            )
+            print(
+                "Required for an intentional CPU/skip-CUDA path: enable both "
+                "NSSMPC_SKIP_CUTLASS and NSSMPC_SKIP_CSPRNG_CUDA, or unset both "
+                "and satisfy the CUDA build requirements."
+            )
+            return 1
+
+        print_status("WARN", "CUDA extension skip flags are enabled.")
+        if skip_cutlass:
+            print("  NSSMPC_SKIP_CUTLASS: enabled")
+        if skip_csprng_cuda:
+            print("  NSSMPC_SKIP_CSPRNG_CUDA: enabled")
+        print("Result: installation may proceed, but some CUDA extensions may be skipped.")
+        print(
+            "Required for this path: PyTorch "
+            f">= {version_text(MIN_TORCH_VERSION)}, setuptools "
+            f">= {version_text(MIN_SETUPTOOLS_VERSION)}, wheel, and a native C/C++ compiler."
+        )
+        return 0
 
     if torch_info.cuda_version and torch_info.cuda_available:
         exact = matching_nvcc(torch_info.cuda_version, nvccs)
         if exact:
-            print("CUDA PyTorch and a matching nvcc were detected.")
-            print("setup.py will auto-detect CUDA_HOME and TORCH_CUDA_ARCH_LIST.")
-            print_command(
-                "pip install -e . --no-build-isolation",
-                "Run this command to install NssMPClib with CUDA extensions:",
-            )
-            return
+            missing_headers, include_dirs = missing_cuda_headers()
+            if missing_headers:
+                print_status("FAIL", "CUDA development headers are missing.")
+                print("Missing headers: " + ", ".join(missing_headers))
+                print("Reason: native CUDA extensions need CUDA headers in addition to nvcc.")
+                print(
+                    "Required: CUDA development headers matching "
+                    f"torch.version.cuda ({torch_info.cuda_version})."
+                )
+                print("Checked include directories:")
+                if include_dirs:
+                    for include_dir in include_dirs:
+                        print(f"  {include_dir}")
+                else:
+                    print("  <none>")
+                return 1
+
+            compiler_issue = detect_cuda_compiler_issue(torch_info.cuda_version)
+            if compiler_issue:
+                print_status("FAIL", "C++ compiler version is incompatible with this CUDA/PyTorch build.")
+                print("Reason: " + compiler_issue)
+                print(
+                    "Required: use a host C++ compiler version within PyTorch's "
+                    f"CUDA {torch_info.cuda_version} bounds, or intentionally use the CPU/skip-CUDA path."
+                )
+                return 1
+
+            print_status("PASS", "CUDA PyTorch and matching nvcc were detected.")
+            print_kv("torch.version.cuda", torch_info.cuda_version)
+            print_kv("nvcc path", exact.path)
+            print_kv("nvcc release", exact.release)
+            print("Result: environment is ready for CUDA extension builds.")
+            return 0
 
         major_match = major_matching_nvcc(torch_info.cuda_version, nvccs)
+
+        print_status("FAIL", "CUDA PyTorch is installed, but matching nvcc was not found.")
+        print_kv("torch.version.cuda", torch_info.cuda_version)
+
         if major_match:
-            print(
-                f"PyTorch was built for CUDA {torch_info.cuda_version}, but the closest nvcc "
-                f"is {major_match.release} at {major_match.path}."
-            )
+            print_kv("closest nvcc path", major_match.path)
+            print_kv("closest nvcc release", major_match.release)
+            print("Reason: an nvcc with the same major CUDA version exists, but the minor version differs.")
+        elif nvccs:
+            print("Detected nvcc versions:")
+            for info in nvccs:
+                print(f"  {info.path} release {info.release or 'unknown'}")
+            print("Reason: none of the detected nvcc versions exactly match torch.version.cuda.")
         else:
-            print(f"PyTorch was built for CUDA {torch_info.cuda_version}, but no matching nvcc was found.")
+            print("Detected nvcc: none")
+            print("Reason: CUDA Toolkit compiler is missing, or nvcc is not visible through PATH/CUDA_HOME.")
 
         print(
-            "Install the CUDA Toolkit / nvcc version that matches torch.version.cuda, "
-            "then rerun the installation advice script."
+            "Expected: provide an nvcc release matching torch.version.cuda, "
+            "or use a PyTorch build that matches the available nvcc."
         )
-
-        codename = ubuntu_codename()
-        if codename:
-            print("Ubuntu apt example:")
-            print_command(
-                "wget https://developer.download.nvidia.com/compute/cuda/repos/"
-                f"{codename}/x86_64/cuda-keyring_1.1-1_all.deb\n"
-                "sudo dpkg -i cuda-keyring_1.1-1_all.deb\n"
-                "sudo apt-get update\n"
-                f"sudo apt-get install -y {cuda_apt_package(torch_info.cuda_version)}\n"
-                f"export CUDA_HOME=/usr/local/cuda-{torch_info.cuda_version}",
-                "Run these commands to install the matching CUDA Toolkit on Ubuntu:",
-            )
-        else:
-            print("CUDA Toolkit download page:")
-            print_command(
-                f"https://developer.nvidia.com/cuda-{torch_info.cuda_version}-0-download-archive",
-                "Open this page and install the matching CUDA Toolkit:",
-            )
-
-        print("If you prefer matching PyTorch to an existing toolkit instead, reinstall torch with:")
-        print_command(
-            f"pip install torch torchvision torchaudio --index-url {torch_index(torch_info.cuda_version)}",
-            "Alternative command:",
+        print(
+            "Required CUDA version: "
+            f"CUDA Toolkit / nvcc {torch_info.cuda_version} for this PyTorch build."
         )
-        print("After fixing the toolkit or PyTorch version, rerun: python3 scripts/installation_advice.py")
-        return
+        preferred = preferred_nvcc(nvccs)
+        if preferred and preferred.release:
+            picked = pytorch_cu_index_for(preferred.release)
+            if picked:
+                print(
+                    "Alternative version target: use a CUDA PyTorch build with "
+                    f"torch.version.cuda={picked} to match detected nvcc {preferred.release}."
+                )
+        print(
+            "Note: PyTorch CUDA wheels can provide CUDA runtime libraries, "
+            "but native CUDA extension builds still require an nvcc compiler."
+        )
+        return 1
 
     if torch_info.cuda_version and not torch_info.cuda_available:
+        if force_cuda:
+            exact = matching_nvcc(torch_info.cuda_version, nvccs)
+            if not exact:
+                print_status("FAIL", "FORCE_CUDA is enabled, but matching nvcc was not found.")
+                print_kv("torch.version.cuda", torch_info.cuda_version)
+                if nvccs:
+                    print("Detected nvcc versions:")
+                    for info in nvccs:
+                        print(f"  {info.path} release {info.release or 'unknown'}")
+                else:
+                    print("Detected nvcc: none")
+                print(
+                    "Required: CUDA Toolkit / nvcc "
+                    f"{torch_info.cuda_version}, matching torch.version.cuda."
+                )
+                return 1
+
+            missing_headers, include_dirs = missing_cuda_headers()
+            if missing_headers:
+                print_status("FAIL", "FORCE_CUDA is enabled, but CUDA development headers are missing.")
+                print("Missing headers: " + ", ".join(missing_headers))
+                print(
+                    "Required: CUDA development headers matching "
+                    f"torch.version.cuda ({torch_info.cuda_version})."
+                )
+                print("Checked include directories:")
+                if include_dirs:
+                    for include_dir in include_dirs:
+                        print(f"  {include_dir}")
+                else:
+                    print("  <none>")
+                return 1
+
+            compiler_issue = detect_cuda_compiler_issue(torch_info.cuda_version)
+            if compiler_issue:
+                print_status("FAIL", "FORCE_CUDA is enabled, but the C++ compiler is incompatible.")
+                print("Reason: " + compiler_issue)
+                print(
+                    "Required: use a host C++ compiler version within PyTorch's "
+                    f"CUDA {torch_info.cuda_version} bounds."
+                )
+                return 1
+
+            print_status("WARN", "FORCE_CUDA is enabled while no GPU is visible to PyTorch.")
+            print_kv("torch.version.cuda", torch_info.cuda_version)
+            print_kv("nvcc path", exact.path)
+            print_kv("nvcc release", exact.release)
+            print(
+                "Result: CUDA extension builds may proceed for an offline/headless build. "
+                "Set TORCH_CUDA_ARCH_LIST explicitly if the default architectures are not appropriate."
+            )
+            return 0
+
+        print_status("FAIL", "PyTorch was built with CUDA, but CUDA is not available at runtime.")
+        print_kv("torch.version.cuda", torch_info.cuda_version)
+        print("Reason: the NVIDIA driver, GPU visibility, container passthrough, or CUDA runtime may be misconfigured.")
         print(
-            f"PyTorch was built with CUDA {torch_info.cuda_version}, but torch.cuda.is_available() is false."
+            "Required for GPU path: NVIDIA driver/runtime visible to PyTorch, "
+            f"plus CUDA Toolkit / nvcc {torch_info.cuda_version} for native CUDA extension builds."
         )
-        print("Check the NVIDIA driver, container GPU passthrough, or CUDA_VISIBLE_DEVICES first.")
-        print("For a non-GPU install, use:")
-        print_command("NSSMPC_SKIP_CUTLASS=1 NSSMPC_SKIP_CSPRNG_CUDA=1 pip install -e . --no-build-isolation")
-        return
+        driver_cuda = nvidia_smi_driver_cuda()
+        if driver_cuda:
+            print(f"Detected driver-supported CUDA max: {driver_cuda}")
+        print(
+            "Expected: make CUDA visible to PyTorch, or intentionally use a "
+            f"CPU-only PyTorch build >= {version_text(MIN_TORCH_VERSION)}."
+        )
+        return 1
 
     has_nvidia_smi, smi_output = detect_nvidia_smi()
     if has_nvidia_smi:
-        print("PyTorch is installed as a CPU-only build, though an NVIDIA driver is present.")
+        print_status("WARN", "PyTorch is CPU-only, but an NVIDIA driver/GPU was detected.")
         if smi_output:
             print("Detected GPUs:")
             for line in smi_output.splitlines():
                 print(f"  {line}")
-        print(
-            "setup.py and csprng/setup.py both auto-skip their CUDA extensions when "
-            "torch is CPU-only, so the standard install below works as-is for a CPU run."
-        )
-        print_command(
-            "pip install -e . --no-build-isolation",
-            "Run this command to install NssMPClib (CPU path):",
-        )
-        compute_caps = nvidia_smi_compute_caps()
-        if not all_compute_caps_too_old(compute_caps):
-            driver_cuda = nvidia_smi_driver_cuda()
-            picked = recommended_cuda_torch_index(nvccs, driver_cuda)
-            if picked:
-                cu_version, cu_url = picked
-                label = f"cu{cu_version.replace('.', '')}"
-                print()
-                print(
-                    f"If you would rather use the GPU, install CUDA torch ({label}) first, "
-                    "then rerun this script:"
-                )
-                print_command(
-                    f"pip install torch torchvision torchaudio --index-url {cu_url}",
-                    f"Optional CUDA torch install ({label}):",
-                )
-        return
 
-    print("CPU-only environment detected; setup.py will auto-skip the CUDA extensions.")
-    print_command(
-        "pip install -e . --no-build-isolation",
-        "Run this command to install NssMPClib (CPU path):",
+        compute_caps = nvidia_smi_compute_caps()
+        if all_compute_caps_too_old(compute_caps):
+            cap_str = ", ".join(compute_caps) if compute_caps else "<unknown>"
+            min_cap = f"sm_{MIN_PYTORCH_COMPUTE_CAP[0]}{MIN_PYTORCH_COMPUTE_CAP[1]}"
+            print(f"Reason: reported GPU compute capability ({cap_str}) is below {min_cap}.")
+            print("Result: CPU-only installation is likely the appropriate path.")
+            return 0
+
+        driver_cuda = nvidia_smi_driver_cuda()
+        if driver_cuda:
+            compatible_index = pytorch_cu_index_for(driver_cuda)
+            print_kv("driver-supported CUDA max", driver_cuda)
+            if compatible_index:
+                print(
+                    "Observation: a CUDA-enabled PyTorch build may be possible "
+                    f"for this driver; highest known family here is {cuda_label(compatible_index)}."
+                )
+            else:
+                print("Observation: no known PyTorch CUDA wheel index fits this driver version.")
+
+        print("Result: CPU installation may proceed, but GPU acceleration will not be used.")
+        print(
+            "Expected: use a CUDA-enabled PyTorch build only if GPU support is required; "
+            "then install a CUDA Toolkit / nvcc with the same torch.version.cuda X.Y."
+        )
+        return 0
+
+    print_status("PASS", "CPU-only environment detected.")
+    print("Result: no NVIDIA GPU runtime was detected; CPU installation path is valid.")
+    print(
+        "Required for this path: CPU-only PyTorch "
+        f">= {version_text(MIN_TORCH_VERSION)}; CUDA Toolkit / nvcc is not required."
     )
+    return 0
 
 
 def main() -> int:
@@ -574,7 +962,7 @@ def main() -> int:
     nvccs = detect_nvccs()
     has_nvidia_smi, smi_output = detect_nvidia_smi()
 
-    print("NssMPClib installation advice")
+    print("NssMPClib environment check")
     print(f"Repository: {root}")
 
     print_section("Environment")
@@ -604,14 +992,17 @@ def main() -> int:
             print(f"nvcc: {info.path} (release {info.release or 'unknown'})")
     else:
         print("nvcc: not found")
+
     if has_nvidia_smi:
         print("nvidia-smi: found")
         if smi_output:
             for line in smi_output.splitlines():
                 print(f"  {line}")
+
         driver_cuda = nvidia_smi_driver_cuda()
         if driver_cuda:
             print(f"driver-supported CUDA (max): {driver_cuda}")
+
         caps = nvidia_smi_compute_caps()
         if caps:
             print("compute capability: " + ", ".join(caps))
@@ -628,19 +1019,23 @@ def main() -> int:
 
     print_section("Build dependencies")
     for name in ("setuptools", "wheel"):
-        try:
-            mod = __import__(name)
-            version = getattr(mod, "__version__", "unknown")
-            print(f"{name}: {version}")
-        except ImportError:
+        version = package_version(name)
+        if version is None:
             print(f"{name}: missing")
+        elif name == "setuptools":
+            print(f"{name}: {version} (required >= {version_text(MIN_SETUPTOOLS_VERSION)})")
+        else:
+            print(f"{name}: {version} (required: installed)")
+
     has_compiler, _ = detect_cpp_compiler()
     print(f"C/C++ compiler: {'found' if has_compiler else 'not found'}")
 
-    recommend(root, torch_info, nvccs)
+    print_required_versions(torch_info, nvccs)
 
-    print("\nNote: this script only recommends commands; it does not install anything.")
-    return 0
+    status = diagnose(root, torch_info, nvccs)
+
+    print("\nNote: this script only diagnoses the environment; it does not install or modify anything.")
+    return status
 
 
 if __name__ == "__main__":

--- a/setup.py
+++ b/setup.py
@@ -1,88 +1,231 @@
+import glob
 import os
+import re
+import subprocess
 import sys
-from setuptools import setup, find_packages
+
+from setuptools import find_packages, setup
 
 
-def auto_fix_cuda_arch():
+def _ensure_submodules():
+    base = os.path.dirname(os.path.abspath(__file__))
+    required = {
+        "cutlass headers": os.path.join(base, "cutlass", "include", "cutlass", "cutlass.h"),
+        "bundled torchcsprng": os.path.join(base, "csprng", "setup.py"),
+    }
+    missing = [f"{name}: {path}" for name, path in required.items() if not os.path.exists(path)]
+    if missing:
+        sys.exit(
+            "Error: required source trees are missing:\n  "
+            + "\n  ".join(missing)
+            + "\nIf you cloned without --recursive, run:\n"
+            "    git submodule update --init --recursive"
+        )
+
+
+def _nvcc_release(cuda_home):
+    if not cuda_home:
+        return None
+    nvcc = os.path.join(cuda_home, "bin", "nvcc")
+    if not os.path.isfile(nvcc):
+        return None
     try:
-        import torch
-        from torch.utils.cpp_extension import BuildExtension, CUDAExtension
-    except ImportError:
-        print("Error: torch must be installed to build CUDA extensions.")
-        sys.exit(1)
+        out = subprocess.check_output([nvcc, "--version"], stderr=subprocess.STDOUT).decode("utf-8", "ignore")
+    except (OSError, subprocess.CalledProcessError):
+        return None
+    m = re.search(r"release (\d+\.\d+)", out)
+    return m.group(1) if m else None
 
-    env_arch = os.environ.get("TORCH_CUDA_ARCH_LIST")
 
-    if not env_arch or env_arch == "Common":
-        print(
-            f"Notice: TORCH_CUDA_ARCH_LIST is '{env_arch}'. Attempting auto-detection...")
+def _auto_set_cuda_home(torch_cuda):
+    """Pick a /usr/local/cuda-* whose nvcc release matches torch.version.cuda.
 
-        try:
-            if not torch.cuda.is_available():
-                detected_arch = "8.0 8.6"
-                print("Warning: No GPU detected. Fallback to: " + detected_arch)
-            else:
-                arch_list = []
-                for i in range(torch.cuda.device_count()):
-                    cap = torch.cuda.get_device_capability(i)
-                    arch = f"{cap[0]}.{cap[1]}"
-                    if arch not in arch_list:
-                        arch_list.append(arch)
-                detected_arch = " ".join(arch_list)
-                print(f"Auto-detected CUDA Architectures: {detected_arch}")
-                
-            os.environ["TORCH_CUDA_ARCH_LIST"] = detected_arch
+    PyTorch's cpp_extension compares torch.version.cuda against the system nvcc
+    and refuses to build on mismatch. On hosts with multiple CUDA toolkits
+    side-by-side (common on Ubuntu), the /usr/local/cuda symlink often points
+    at the wrong one. We try to repair CUDA_HOME automatically before the
+    BuildExtension runs and emit an actionable message if we can't.
+    """
+    if not torch_cuda:
+        return  # CPU-only torch; nothing to align.
 
-        except Exception as e:
+    current = os.environ.get("CUDA_HOME") or "/usr/local/cuda"
+    if _nvcc_release(current) == torch_cuda:
+        return
+
+    candidates = sorted(glob.glob("/usr/local/cuda-*"), reverse=True)
+
+    for cand in candidates:
+        if _nvcc_release(cand) == torch_cuda:
+            os.environ["CUDA_HOME"] = cand
+            print(f"Notice: auto-set CUDA_HOME={cand} (matches torch.version.cuda={torch_cuda})")
+            return
+
+    major = torch_cuda.split(".")[0]
+    for cand in candidates:
+        rel = _nvcc_release(cand)
+        if rel and rel.split(".")[0] == major:
+            os.environ["CUDA_HOME"] = cand
             print(
-                f"Warning: Auto-detection failed ({e}). using default 8.0 8.6")
-            os.environ["TORCH_CUDA_ARCH_LIST"] = "8.0 8.6"
+                f"Warning: no exact CUDA {torch_cuda} toolkit found; using {cand} (release {rel}). "
+                "PyTorch may emit a minor-version mismatch warning."
+            )
+            return
+
+    _print_toolkit_install_guide(torch_cuda)
+
+
+def _detect_ubuntu_codename():
+    try:
+        with open("/etc/os-release") as f:
+            data = dict(
+                line.strip().split("=", 1)
+                for line in f
+                if "=" in line and not line.startswith("#")
+            )
+    except OSError:
+        return None
+    if data.get("ID", "").strip('"').lower() != "ubuntu":
+        return None
+    ver = data.get("VERSION_ID", "").strip('"').replace(".", "")
+    return f"ubuntu{ver}" if ver else None
+
+
+def _print_toolkit_install_guide(torch_cuda):
+    """Print actionable install commands for the missing CUDA toolkit."""
+    cu_short = f"cu{torch_cuda.replace('.', '')}"
+    major_minor = torch_cuda  # e.g. "12.8"
+    apt_pkg = f"cuda-toolkit-{torch_cuda.replace('.', '-')}"  # cuda-toolkit-12-8
+
+    lines = [
+        f"Warning: torch was built against CUDA {torch_cuda} but no matching "
+        f"/usr/local/cuda-* was found (CUDA_HOME='{os.environ.get('CUDA_HOME')}').",
+        "",
+        f"Pick one of the following to proceed:",
+        "",
+        f"  [A] Install the matching CUDA {major_minor} toolkit via conda (recommended; no sudo):",
+        f"        conda install -c nvidia/label/cuda-{major_minor}.0 "
+        f"cuda-nvcc cuda-cudart-dev cuda-libraries-dev",
+        f"      then re-run `pip install -e . --no-build-isolation`.",
+        "",
+    ]
+
+    codename = _detect_ubuntu_codename()
+    if codename:
+        lines += [
+            f"  [B] Install via apt on {codename}:",
+            f"        wget https://developer.download.nvidia.com/compute/cuda/repos/"
+            f"{codename}/x86_64/cuda-keyring_1.1-1_all.deb",
+            f"        sudo dpkg -i cuda-keyring_1.1-1_all.deb",
+            f"        sudo apt-get update && sudo apt-get install -y {apt_pkg}",
+            f"        export CUDA_HOME=/usr/local/cuda-{major_minor}",
+            "",
+        ]
     else:
+        lines += [
+            f"  [B] Install via your OS package manager — see "
+            f"https://developer.nvidia.com/cuda-{major_minor}-0-download-archive",
+            "",
+        ]
+
+    lines += [
+        f"  [C] Reinstall torch to match the toolkit already on this host, e.g.:",
+        f"        pip install torch --index-url https://download.pytorch.org/whl/{cu_short}",
+        "",
+        f"  [D] Skip the CUDA extension (CPU/Triton fallback at runtime):",
+        f"        NSSMPC_SKIP_CUTLASS=1 pip install -e . --no-build-isolation",
+    ]
+    print("\n".join(lines), file=sys.stderr)
+
+
+def _set_torch_cuda_arch_list(torch):
+    env_arch = os.environ.get("TORCH_CUDA_ARCH_LIST")
+    if env_arch and env_arch != "Common":
         print(f"Using existing TORCH_CUDA_ARCH_LIST: {env_arch}")
+        return
 
-    return BuildExtension, CUDAExtension
+    fallback = "8.0 8.6"
+    try:
+        if not torch.cuda.is_available():
+            os.environ["TORCH_CUDA_ARCH_LIST"] = fallback
+            print(f"Notice: no GPU detected at build time; defaulting TORCH_CUDA_ARCH_LIST={fallback}")
+            return
+        arch_list = []
+        for i in range(torch.cuda.device_count()):
+            cap = torch.cuda.get_device_capability(i)
+            arch = f"{cap[0]}.{cap[1]}"
+            if arch not in arch_list:
+                arch_list.append(arch)
+        detected = " ".join(arch_list) or fallback
+        os.environ["TORCH_CUDA_ARCH_LIST"] = detected
+        print(f"Auto-detected TORCH_CUDA_ARCH_LIST={detected}")
+    except Exception as e:
+        os.environ["TORCH_CUDA_ARCH_LIST"] = fallback
+        print(f"Warning: CUDA arch auto-detection failed ({e}); defaulted to {fallback}")
 
 
-BuildExtension, CUDAExtension = auto_fix_cuda_arch()
+_ensure_submodules()
+
+try:
+    import torch
+    from torch.utils.cpp_extension import BuildExtension, CUDAExtension
+except ImportError:
+    sys.exit(
+        "Error: torch must be installed before building NssMPClib.\n"
+        "Install a torch wheel that matches your CUDA toolkit, e.g.:\n"
+        "    pip install torch==2.7.1 --index-url https://download.pytorch.org/whl/cu128\n"
+        "Then re-run `pip install -e . --no-build-isolation`."
+    )
+
+_auto_set_cuda_home(torch.version.cuda)
+_set_torch_cuda_arch_list(torch)
 
 base_path = os.path.dirname(os.path.abspath(__file__))
 
-cutlass_include_dir = os.path.join(base_path, 'cutlass', 'include')
-cutlass_util_include_dir = os.path.join(
-    base_path, 'cutlass', 'tools', 'util', 'include')
+cutlass_include_dir = os.path.join(base_path, "cutlass", "include")
+cutlass_util_include_dir = os.path.join(base_path, "cutlass", "tools", "util", "include")
+kernel_source_file = os.path.join("nssmpc", "infra", "utils", "nss_cutlass_kernels.cu")
 
-kernel_source_file = os.path.join(
-    'nssmpc', 'infra', 'utils', 'nss_cutlass_kernels.cu')
+SKIP_CUTLASS = os.environ.get("NSSMPC_SKIP_CUTLASS", "").lower() in ("1", "true", "yes")
 
-if not os.path.exists(kernel_source_file):
-    print(f"Error: Source file not found at {kernel_source_file}")
-    sys.exit(1)
+ext_modules = []
+cmdclass = {}
 
-nvcc_flags = [
-    '-O3',
-    '-std=c++17',                   
-    '--expt-relaxed-constexpr',
-    '-D__CUDA_NO_HALF_OPERATORS__',
-    '-D__CUDA_NO_HALF_CONVERSIONS__',
-]
-
-cxx_flags = ['-O3', '-std=c++17']
-
-ext_modules = [
-    CUDAExtension(
-        name='nssmpc.infra.utils.cutlass_kernels',
-        sources=[kernel_source_file],
-        include_dirs=[
-            cutlass_include_dir,
-            cutlass_util_include_dir,
-            os.path.dirname(kernel_source_file)
-        ],
-        extra_compile_args={
-            'cxx': cxx_flags,
-            'nvcc': nvcc_flags,
-        },
+if SKIP_CUTLASS:
+    print(
+        "Notice: NSSMPC_SKIP_CUTLASS is set; skipping CUTLASS extension. "
+        "The runtime will fall back to the pure-PyTorch matmul path "
+        "(see nssmpc/infra/utils/cuda.py)."
     )
-]
+elif not torch.version.cuda:
+    print(
+        "Notice: torch is CPU-only; skipping CUTLASS extension build. "
+        "Install a CUDA-enabled torch and reinstall to enable the fast matmul path."
+    )
+elif not os.path.exists(kernel_source_file):
+    print(f"Warning: kernel source {kernel_source_file} not found; skipping CUTLASS extension.")
+else:
+    nvcc_flags = [
+        "-O3",
+        "-std=c++17",
+        "--expt-relaxed-constexpr",
+        "-D__CUDA_NO_HALF_OPERATORS__",
+        "-D__CUDA_NO_HALF_CONVERSIONS__",
+    ]
+    cxx_flags = ["-O3", "-std=c++17"]
+    ext_modules = [
+        CUDAExtension(
+            name="nssmpc.infra.utils.cutlass_kernels",
+            sources=[kernel_source_file],
+            include_dirs=[
+                cutlass_include_dir,
+                cutlass_util_include_dir,
+                os.path.dirname(kernel_source_file),
+            ],
+            extra_compile_args={"cxx": cxx_flags, "nvcc": nvcc_flags},
+        )
+    ]
+    cmdclass = {"build_ext": BuildExtension}
 
 setup(
     name="NssMPClib",
@@ -95,10 +238,10 @@ setup(
     packages=find_packages(),
     include_package_data=True,
     ext_modules=ext_modules,
-    cmdclass={'build_ext': BuildExtension},
+    cmdclass=cmdclass,
     install_requires=[
-        f'torchcsprng @ file://localhost/{base_path}/csprng',
-        'torch>=2.3.0',
+        f"torchcsprng @ file://{base_path}/csprng",
+        "torch>=2.5.0",
     ],
     classifiers=[
         "Development Status :: 4 - Beta",

--- a/setup.py
+++ b/setup.py
@@ -103,17 +103,12 @@ def _print_toolkit_install_guide(torch_cuda):
         "",
         f"Pick one of the following to proceed:",
         "",
-        f"  [A] Install the matching CUDA {major_minor} toolkit via conda (recommended; no sudo):",
-        f"        conda install -c nvidia/label/cuda-{major_minor}.0 "
-        f"cuda-nvcc cuda-cudart-dev cuda-libraries-dev",
-        f"      then re-run `pip install -e . --no-build-isolation`.",
-        "",
     ]
 
     codename = _detect_ubuntu_codename()
     if codename:
         lines += [
-            f"  [B] Install via apt on {codename}:",
+            f"  [A] Install CUDA Toolkit {major_minor} via apt on {codename}:",
             f"        wget https://developer.download.nvidia.com/compute/cuda/repos/"
             f"{codename}/x86_64/cuda-keyring_1.1-1_all.deb",
             f"        sudo dpkg -i cuda-keyring_1.1-1_all.deb",
@@ -123,17 +118,17 @@ def _print_toolkit_install_guide(torch_cuda):
         ]
     else:
         lines += [
-            f"  [B] Install via your OS package manager — see "
+            f"  [A] Install CUDA Toolkit {major_minor} via your OS package manager — see "
             f"https://developer.nvidia.com/cuda-{major_minor}-0-download-archive",
             "",
         ]
 
     lines += [
-        f"  [C] Reinstall torch to match the toolkit already on this host, e.g.:",
+        f"  [B] Reinstall torch to match the toolkit already on this host, e.g.:",
         f"        pip install torch --index-url https://download.pytorch.org/whl/{cu_short}",
         "",
-        f"  [D] Skip the CUDA extension (CPU/Triton fallback at runtime):",
-        f"        NSSMPC_SKIP_CUTLASS=1 pip install -e . --no-build-isolation",
+        f"  [C] Use the standard install without local CUDA extension compilation:",
+        f"        NSSMPC_SKIP_CUTLASS=1 NSSMPC_SKIP_CSPRNG_CUDA=1 pip install -e . --no-build-isolation",
     ]
     print("\n".join(lines), file=sys.stderr)
 
@@ -168,7 +163,6 @@ _ensure_submodules()
 
 try:
     import torch
-    from torch.utils.cpp_extension import BuildExtension, CUDAExtension
 except ImportError:
     sys.exit(
         "Error: torch must be installed before building NssMPClib.\n"
@@ -179,6 +173,12 @@ except ImportError:
 
 _auto_set_cuda_home(torch.version.cuda)
 _set_torch_cuda_arch_list(torch)
+
+from torch.utils import cpp_extension  # noqa: E402
+from torch.utils.cpp_extension import BuildExtension, CUDAExtension  # noqa: E402
+
+if os.environ.get("CUDA_HOME"):
+    cpp_extension.CUDA_HOME = os.environ["CUDA_HOME"]
 
 base_path = os.path.dirname(os.path.abspath(__file__))
 

--- a/setup.py
+++ b/setup.py
@@ -1,10 +1,56 @@
 import glob
+import importlib.metadata
 import os
 import re
+import shlex
+import shutil
+import site
 import subprocess
 import sys
 
 from setuptools import find_packages, setup
+
+
+YES_VALUES = ("1", "true", "yes", "on")
+MIN_SETUPTOOLS_VERSION = (64,)
+MIN_TORCH_VERSION = (2, 5, 0)
+
+
+def _version_text(version):
+    return ".".join(str(part) for part in version)
+
+
+def _parse_numeric_version(value):
+    if not value:
+        return None
+    match = re.match(r"^\s*(\d+(?:\.\d+)*)", value)
+    if not match:
+        return None
+    return tuple(int(part) for part in match.group(1).split("."))
+
+
+def _version_at_least(value, minimum):
+    parsed = _parse_numeric_version(value)
+    if not parsed:
+        return False
+    size = max(len(parsed), len(minimum))
+    padded = parsed + (0,) * (size - len(parsed))
+    padded_minimum = minimum + (0,) * (size - len(minimum))
+    return padded >= padded_minimum
+
+
+def _version_less_than(value, maximum):
+    parsed = _parse_numeric_version(value)
+    if not parsed:
+        return False
+    size = max(len(parsed), len(maximum))
+    padded = parsed + (0,) * (size - len(parsed))
+    padded_maximum = maximum + (0,) * (size - len(maximum))
+    return padded < padded_maximum
+
+
+def _env_enabled(name):
+    return os.environ.get(name, "").strip().lower() in YES_VALUES
 
 
 def _ensure_submodules():
@@ -18,8 +64,8 @@ def _ensure_submodules():
         sys.exit(
             "Error: required source trees are missing:\n  "
             + "\n  ".join(missing)
-            + "\nIf you cloned without --recursive, run:\n"
-            "    git submodule update --init --recursive"
+            + "\nRequired: initialize or restore the missing Git submodules.\n"
+            "Run scripts/installation_advice.py to inspect the current environment."
         )
 
 
@@ -37,100 +83,236 @@ def _nvcc_release(cuda_home):
     return m.group(1) if m else None
 
 
-def _auto_set_cuda_home(torch_cuda):
-    """Pick a /usr/local/cuda-* whose nvcc release matches torch.version.cuda.
+def _dedupe_existing_paths(paths):
+    result = []
+    seen = set()
 
-    PyTorch's cpp_extension compares torch.version.cuda against the system nvcc
-    and refuses to build on mismatch. On hosts with multiple CUDA toolkits
-    side-by-side (common on Ubuntu), the /usr/local/cuda symlink often points
-    at the wrong one. We try to repair CUDA_HOME automatically before the
-    BuildExtension runs and emit an actionable message if we can't.
-    """
-    if not torch_cuda:
-        return  # CPU-only torch; nothing to align.
+    for path in paths:
+        if not path:
+            continue
 
-    current = os.environ.get("CUDA_HOME") or "/usr/local/cuda"
-    if _nvcc_release(current) == torch_cuda:
+        path = os.path.abspath(path)
+        if path in seen:
+            continue
+
+        if os.path.isdir(path):
+            seen.add(path)
+            result.append(path)
+
+    return result
+
+
+def _cuda_home_candidates():
+    candidates = []
+
+    for env_name in ("CUDA_HOME", "CUDA_PATH", "CONDA_PREFIX"):
+        value = os.environ.get(env_name)
+        if value:
+            candidates.append(value)
+
+    path_nvcc = shutil.which("nvcc")
+    if path_nvcc:
+        candidates.append(os.path.dirname(os.path.dirname(path_nvcc)))
+
+    candidates.append("/usr/local/cuda")
+    candidates.extend(sorted(glob.glob("/usr/local/cuda-*"), reverse=True))
+
+    return _dedupe_existing_paths(candidates)
+
+
+def _python_site_dirs():
+    dirs = []
+
+    try:
+        dirs.extend(site.getsitepackages())
+    except Exception:
+        pass
+
+    try:
+        user_site = site.getusersitepackages()
+        if user_site:
+            dirs.append(user_site)
+    except Exception:
+        pass
+
+    conda_prefix = os.environ.get("CONDA_PREFIX")
+    if conda_prefix:
+        dirs.extend(glob.glob(os.path.join(conda_prefix, "lib", "python*", "site-packages")))
+
+    return _dedupe_existing_paths(dirs)
+
+
+def _cuda_include_dirs():
+    candidates = []
+
+    for root in _cuda_home_candidates():
+        candidates.append(os.path.join(root, "include"))
+        candidates.append(os.path.join(root, "targets", "x86_64-linux", "include"))
+
+    for site_dir in _python_site_dirs():
+        candidates.extend(glob.glob(os.path.join(site_dir, "nvidia", "*", "include")))
+
+    return _dedupe_existing_paths(candidates)
+
+
+def _cuda_library_dirs():
+    candidates = []
+
+    for root in _cuda_home_candidates():
+        candidates.extend(
+            [
+                os.path.join(root, "lib64"),
+                os.path.join(root, "lib"),
+                os.path.join(root, "targets", "x86_64-linux", "lib"),
+                os.path.join(root, "targets", "x86_64-linux", "lib", "stubs"),
+            ]
+        )
+
+    for site_dir in _python_site_dirs():
+        candidates.extend(glob.glob(os.path.join(site_dir, "nvidia", "*", "lib")))
+
+    return _dedupe_existing_paths(candidates)
+
+
+def _ensure_cuda_headers(include_dirs, torch_cuda):
+    missing = []
+
+    for header in ("cuda_runtime.h", "cublas_v2.h"):
+        if not any(os.path.exists(os.path.join(include_dir, header)) for include_dir in include_dirs):
+            missing.append(header)
+
+    if not missing:
         return
 
-    candidates = sorted(glob.glob("/usr/local/cuda-*"), reverse=True)
-
-    for cand in candidates:
-        if _nvcc_release(cand) == torch_cuda:
-            os.environ["CUDA_HOME"] = cand
-            print(f"Notice: auto-set CUDA_HOME={cand} (matches torch.version.cuda={torch_cuda})")
-            return
-
-    major = torch_cuda.split(".")[0]
-    for cand in candidates:
-        rel = _nvcc_release(cand)
-        if rel and rel.split(".")[0] == major:
-            os.environ["CUDA_HOME"] = cand
-            print(
-                f"Warning: no exact CUDA {torch_cuda} toolkit found; using {cand} (release {rel}). "
-                "PyTorch may emit a minor-version mismatch warning."
-            )
-            return
-
-    _print_toolkit_install_guide(torch_cuda)
-
-
-def _detect_ubuntu_codename():
-    try:
-        with open("/etc/os-release") as f:
-            data = dict(
-                line.strip().split("=", 1)
-                for line in f
-                if "=" in line and not line.startswith("#")
-            )
-    except OSError:
-        return None
-    if data.get("ID", "").strip('"').lower() != "ubuntu":
-        return None
-    ver = data.get("VERSION_ID", "").strip('"').replace(".", "")
-    return f"ubuntu{ver}" if ver else None
-
-
-def _print_toolkit_install_guide(torch_cuda):
-    """Print actionable install commands for the missing CUDA toolkit."""
-    cu_short = f"cu{torch_cuda.replace('.', '')}"
-    major_minor = torch_cuda  # e.g. "12.8"
-    apt_pkg = f"cuda-toolkit-{torch_cuda.replace('.', '-')}"  # cuda-toolkit-12-8
-
     lines = [
-        f"Warning: torch was built against CUDA {torch_cuda} but no matching "
-        f"/usr/local/cuda-* was found (CUDA_HOME='{os.environ.get('CUDA_HOME')}').",
-        "",
-        f"Pick one of the following to proceed:",
-        "",
+        "Error: CUDA development headers are missing.",
+        "Missing headers: " + ", ".join(missing),
+        f"Required: CUDA development headers matching torch.version.cuda={torch_cuda}.",
+        "Checked include directories:",
     ]
 
-    codename = _detect_ubuntu_codename()
-    if codename:
-        lines += [
-            f"  [A] Install CUDA Toolkit {major_minor} via apt on {codename}:",
-            f"        wget https://developer.download.nvidia.com/compute/cuda/repos/"
-            f"{codename}/x86_64/cuda-keyring_1.1-1_all.deb",
-            f"        sudo dpkg -i cuda-keyring_1.1-1_all.deb",
-            f"        sudo apt-get update && sudo apt-get install -y {apt_pkg}",
-            f"        export CUDA_HOME=/usr/local/cuda-{major_minor}",
-            "",
-        ]
+    if include_dirs:
+        lines.extend(f"  {include_dir}" for include_dir in include_dirs)
     else:
-        lines += [
-            f"  [A] Install CUDA Toolkit {major_minor} via your OS package manager — see "
-            f"https://developer.nvidia.com/cuda-{major_minor}-0-download-archive",
-            "",
-        ]
+        lines.append("  <none>")
 
-    lines += [
-        f"  [B] Reinstall torch to match the toolkit already on this host, e.g.:",
-        f"        pip install torch --index-url https://download.pytorch.org/whl/{cu_short}",
-        "",
-        f"  [C] Use the standard install without local CUDA extension compilation:",
-        f"        NSSMPC_SKIP_CUTLASS=1 NSSMPC_SKIP_CSPRNG_CUDA=1 pip install -e . --no-build-isolation",
-    ]
-    print("\n".join(lines), file=sys.stderr)
+    lines.append("Run scripts/installation_advice.py to inspect the current environment.")
+    sys.exit("\n".join(lines))
+
+
+def _cxx_compiler_command():
+    env_cxx = os.environ.get("CXX")
+    if env_cxx:
+        return shlex.split(env_cxx)
+
+    if sys.platform.startswith("win"):
+        return ["cl"] if shutil.which("cl") else None
+
+    for name in ("g++", "c++", "clang++"):
+        if shutil.which(name):
+            return [name]
+
+    return None
+
+
+def _compiler_version(command):
+    for args in (command + ["-dumpfullversion", "-dumpversion"], command + ["--version"]):
+        try:
+            out = subprocess.check_output(args, stderr=subprocess.STDOUT).decode("utf-8", "ignore")
+        except (OSError, subprocess.CalledProcessError):
+            continue
+
+        parsed = _parse_numeric_version(out)
+        if parsed:
+            return _version_text(parsed)
+
+    return None
+
+
+def _compiler_kind(command):
+    name = os.path.basename(command[0]).lower()
+    if "clang" in name:
+        return "clang"
+    return "gcc"
+
+
+def _cuda_compiler_issue(torch_cuda, cpp_extension_module):
+    if not torch_cuda or not sys.platform.startswith("linux"):
+        return None
+
+    if os.environ.get("TORCH_DONT_CHECK_COMPILER_ABI", "").upper() in (
+        "ON",
+        "1",
+        "YES",
+        "TRUE",
+        "Y",
+    ):
+        return None
+
+    command = _cxx_compiler_command()
+    if not command:
+        return "No C++ compiler command was found for CUDA extension builds."
+
+    version = _compiler_version(command)
+    if not version:
+        return f"Could not determine C++ compiler version for {' '.join(command)}."
+
+    kind = _compiler_kind(command)
+    bounds_map = (
+        getattr(cpp_extension_module, "CUDA_CLANG_VERSIONS", {})
+        if kind == "clang"
+        else getattr(cpp_extension_module, "CUDA_GCC_VERSIONS", {})
+    )
+    bounds = bounds_map.get(torch_cuda)
+    if not bounds:
+        return None
+
+    min_version, max_exclusive_version = tuple(bounds[0]), tuple(bounds[1])
+    if _version_at_least(version, min_version) and _version_less_than(version, max_exclusive_version):
+        return None
+
+    compiler_name = "clang++" if kind == "clang" else "g++"
+    return (
+        f"Detected {compiler_name}-compatible compiler {' '.join(command)} {version}, "
+        f"but CUDA {torch_cuda} requires {compiler_name} "
+        f">= {_version_text(min_version)}, < {_version_text(max_exclusive_version)} "
+        "for PyTorch CUDA extension builds."
+    )
+
+
+def _ensure_cuda_compiler_compatible(torch_cuda, cpp_extension_module):
+    issue = _cuda_compiler_issue(torch_cuda, cpp_extension_module)
+    if issue:
+        sys.exit(
+            "Error: C++ compiler version is incompatible with this CUDA/PyTorch build.\n"
+            f"Reason: {issue}\n"
+            "Required: use a host C++ compiler version within PyTorch's CUDA compiler bounds, "
+            "or use the intentional CPU/skip-CUDA install path.\n"
+            "Run scripts/installation_advice.py to inspect the current environment."
+        )
+
+
+def _auto_set_cuda_home(torch_cuda):
+    """Pick a CUDA root whose nvcc release exactly matches torch.version.cuda.
+
+    PyTorch's cpp_extension compares torch.version.cuda against the system nvcc
+    and may refuse to build on mismatch. Keep this in sync with
+    scripts/installation_advice.py and csprng/setup.py.
+    """
+    if not torch_cuda:
+        return True
+
+    for candidate in _cuda_home_candidates():
+        if _nvcc_release(candidate) == torch_cuda:
+            os.environ["CUDA_HOME"] = candidate
+            os.environ.setdefault("CUDA_PATH", candidate)
+            print(
+                f"Notice: auto-set CUDA_HOME={candidate} "
+                f"(matches torch.version.cuda={torch_cuda})"
+            )
+            return True
+
+    return False
 
 
 def _set_torch_cuda_arch_list(torch):
@@ -178,18 +360,14 @@ def _ensure_cpp_compiler():
         if any(glob.glob(p) for p in cl_patterns):
             sys.exit(
                 "Error: Microsoft Visual C++ appears to be installed but 'cl' is not on PATH.\n"
-                "Open the 'x64 Native Tools Command Prompt for VS' (or run vcvarsall.bat) "
-                "so that the compiler is reachable, then re-run "
-                "`pip install -e . --no-build-isolation`."
+                "Required: make the Visual C++ compiler reachable on PATH before building.\n"
+                "Run scripts/installation_advice.py to inspect the current environment."
             )
         sys.exit(
             "Error: no C/C++ compiler was found, but torchcsprng's native extension "
             "must be compiled from source.\n"
-            "Install 'Build Tools for Visual Studio' (free) from\n"
-            "    https://visualstudio.microsoft.com/visual-cpp-build-tools/\n"
-            "with the 'Desktop development with C++' workload. Then open the "
-            "'x64 Native Tools Command Prompt for VS' (so 'cl' is on PATH) and "
-            "re-run `pip install -e . --no-build-isolation`."
+            "Required on Windows: Microsoft Visual C++ 14.0 or newer, with 'cl' on PATH.\n"
+            "Run scripts/installation_advice.py to inspect the current environment."
         )
 
     for name in ("c++", "g++", "clang++", "cc", "gcc", "clang"):
@@ -198,37 +376,63 @@ def _ensure_cpp_compiler():
     sys.exit(
         "Error: no C/C++ compiler was found, but torchcsprng's native extension "
         "must be compiled from source.\n"
-        "On Ubuntu/Debian: sudo apt-get install build-essential\n"
-        "Then re-run `pip install -e . --no-build-isolation`."
+        "Required on Linux: a system C/C++ compiler such as gcc/g++ or clang.\n"
+        "Run scripts/installation_advice.py to inspect the current environment."
+    )
+
+
+def _ensure_python_build_deps():
+    try:
+        setuptools_version = importlib.metadata.version("setuptools")
+    except importlib.metadata.PackageNotFoundError:
+        setuptools_version = None
+
+    if not setuptools_version or not _version_at_least(setuptools_version, MIN_SETUPTOOLS_VERSION):
+        current = setuptools_version or "missing"
+        sys.exit(
+            "Error: setuptools is required to build NssMPClib with "
+            f"--no-build-isolation, and must be >= {_version_text(MIN_SETUPTOOLS_VERSION)}.\n"
+            f"Current setuptools: {current}\n"
+            "Run scripts/installation_advice.py to inspect the current environment."
+        )
+
+    try:
+        import wheel  # noqa: F401
+    except ImportError:
+        sys.exit(
+            "Error: the 'wheel' package is required to build NssMPClib with "
+            "--no-build-isolation, but it is not installed in this environment.\n"
+            "Run scripts/installation_advice.py to inspect the current environment."
+        )
+
+
+def _ensure_torch_version(torch):
+    version = getattr(torch, "__version__", None)
+    if _version_at_least(version, MIN_TORCH_VERSION):
+        return
+
+    sys.exit(
+        "Error: PyTorch is too old for NssMPClib.\n"
+        f"Required: torch >= {_version_text(MIN_TORCH_VERSION)}.\n"
+        f"Current torch: {version or '<unknown>'}.\n"
+        "Run scripts/installation_advice.py to inspect the current environment."
     )
 
 
 _ensure_submodules()
 _ensure_cpp_compiler()
-
-try:
-    import wheel  # noqa: F401
-except ImportError:
-    sys.exit(
-        "Error: the 'wheel' package is required to build NssMPClib with "
-        "--no-build-isolation, but it is not installed in this environment.\n"
-        "Install it first:\n"
-        "    pip install --upgrade setuptools wheel\n"
-        "Then re-run `pip install -e . --no-build-isolation`."
-    )
+_ensure_python_build_deps()
 
 try:
     import torch
 except ImportError:
     sys.exit(
         "Error: torch must be installed before building NssMPClib.\n"
-        "Install a torch wheel that matches your CUDA toolkit, e.g.:\n"
-        "    pip install torch==2.7.1 --index-url https://download.pytorch.org/whl/cu128\n"
-        "Then re-run `pip install -e . --no-build-isolation`."
+        "Required: torch >= 2.5.0, with a CPU or CUDA variant chosen intentionally.\n"
+        "Run scripts/installation_advice.py to inspect the current environment."
     )
 
-_auto_set_cuda_home(torch.version.cuda)
-_set_torch_cuda_arch_list(torch)
+_ensure_torch_version(torch)
 
 from torch.utils import cpp_extension  # noqa: E402
 from torch.utils.cpp_extension import BuildExtension, CUDAExtension  # noqa: E402
@@ -242,7 +446,20 @@ cutlass_include_dir = os.path.join(base_path, "cutlass", "include")
 cutlass_util_include_dir = os.path.join(base_path, "cutlass", "tools", "util", "include")
 kernel_source_file = os.path.join("nssmpc", "infra", "utils", "nss_cutlass_kernels.cu")
 
-SKIP_CUTLASS = os.environ.get("NSSMPC_SKIP_CUTLASS", "").lower() in ("1", "true", "yes")
+SKIP_CUTLASS = _env_enabled("NSSMPC_SKIP_CUTLASS")
+SKIP_CSPRNG_CUDA = _env_enabled("NSSMPC_SKIP_CSPRNG_CUDA")
+FORCE_CUDA = os.environ.get("FORCE_CUDA", "0") == "1"
+
+if torch.version.cuda and (SKIP_CUTLASS or SKIP_CSPRNG_CUDA) and not (
+    SKIP_CUTLASS and SKIP_CSPRNG_CUDA
+):
+    sys.exit(
+        "Error: CUDA extension skip flags are incomplete.\n"
+        "Required for an intentional CPU/skip-CUDA NssMPClib install: set both "
+        "NSSMPC_SKIP_CUTLASS=1 and NSSMPC_SKIP_CSPRNG_CUDA=1.\n"
+        "Alternatively, unset both flags and satisfy the CUDA build requirements.\n"
+        "Run scripts/installation_advice.py to inspect the current environment."
+    )
 
 ext_modules = []
 cmdclass = {}
@@ -258,9 +475,35 @@ elif not torch.version.cuda:
         "Notice: torch is CPU-only; skipping CUTLASS extension build. "
         "Install a CUDA-enabled torch and reinstall to enable the fast matmul path."
     )
+elif not torch.cuda.is_available() and not FORCE_CUDA:
+    sys.exit(
+        "Error: torch was built with CUDA, but torch.cuda.is_available() is false.\n"
+        "NssMPClib will not build CUDA extensions from this ambiguous state.\n"
+        "Required for the CUDA path: GPU/runtime visible to PyTorch, matching nvcc, "
+        "and CUDA development headers.\n"
+        "For an intentional CPU/skip-CUDA install, set NSSMPC_SKIP_CUTLASS=1 "
+        "and NSSMPC_SKIP_CSPRNG_CUDA=1.\n"
+        "Run scripts/installation_advice.py to inspect the current environment."
+    )
 elif not os.path.exists(kernel_source_file):
     print(f"Warning: kernel source {kernel_source_file} not found; skipping CUTLASS extension.")
 else:
+    if not _auto_set_cuda_home(torch.version.cuda):
+        sys.exit(
+            "Error: CUDA PyTorch is installed, but no matching CUDA Toolkit / nvcc was found.\n"
+            f"Required: CUDA Toolkit / nvcc {torch.version.cuda}, matching torch.version.cuda.\n"
+            "Run scripts/installation_advice.py to inspect the current environment."
+        )
+
+    if os.environ.get("CUDA_HOME"):
+        cpp_extension.CUDA_HOME = os.environ["CUDA_HOME"]
+
+    cuda_include_dirs = _cuda_include_dirs()
+    cuda_library_dirs = _cuda_library_dirs()
+    _ensure_cuda_headers(cuda_include_dirs, torch.version.cuda)
+    _ensure_cuda_compiler_compatible(torch.version.cuda, cpp_extension)
+    _set_torch_cuda_arch_list(torch)
+
     nvcc_flags = [
         "-O3",
         "-std=c++17",
@@ -277,7 +520,9 @@ else:
                 cutlass_include_dir,
                 cutlass_util_include_dir,
                 os.path.dirname(kernel_source_file),
-            ],
+            ]
+            + cuda_include_dirs,
+            library_dirs=cuda_library_dirs,
             extra_compile_args={"cxx": cxx_flags, "nvcc": nvcc_flags},
         )
     ]
@@ -299,6 +544,7 @@ setup(
         f"torchcsprng @ file://{base_path}/csprng",
         "torch>=2.5.0",
     ],
+    python_requires=">=3.10",
     classifiers=[
         "Development Status :: 4 - Beta",
         "Intended Audience :: Science/Research",

--- a/setup.py
+++ b/setup.py
@@ -159,7 +159,63 @@ def _set_torch_cuda_arch_list(torch):
         print(f"Warning: CUDA arch auto-detection failed ({e}); defaulted to {fallback}")
 
 
+def _ensure_cpp_compiler():
+    """torchcsprng always builds a native extension, so a C/C++ compiler is required."""
+    import glob
+    import platform
+    import shutil
+
+    if platform.system() == "Windows":
+        if shutil.which("cl"):
+            return
+        # Look for an actual cl.exe inside common VS / Build Tools layouts —
+        # directory existence alone isn't enough (installer leaves empty stubs).
+        cl_patterns = [
+            r"C:\Program Files\Microsoft Visual Studio\*\*\VC\Tools\MSVC\*\bin\Host*\*\cl.exe",
+            r"C:\Program Files (x86)\Microsoft Visual Studio\*\*\VC\Tools\MSVC\*\bin\Host*\*\cl.exe",
+            r"C:\BuildTools\VC\Tools\MSVC\*\bin\Host*\*\cl.exe",
+        ]
+        if any(glob.glob(p) for p in cl_patterns):
+            sys.exit(
+                "Error: Microsoft Visual C++ appears to be installed but 'cl' is not on PATH.\n"
+                "Open the 'x64 Native Tools Command Prompt for VS' (or run vcvarsall.bat) "
+                "so that the compiler is reachable, then re-run "
+                "`pip install -e . --no-build-isolation`."
+            )
+        sys.exit(
+            "Error: no C/C++ compiler was found, but torchcsprng's native extension "
+            "must be compiled from source.\n"
+            "Install 'Build Tools for Visual Studio' (free) from\n"
+            "    https://visualstudio.microsoft.com/visual-cpp-build-tools/\n"
+            "with the 'Desktop development with C++' workload. Then open the "
+            "'x64 Native Tools Command Prompt for VS' (so 'cl' is on PATH) and "
+            "re-run `pip install -e . --no-build-isolation`."
+        )
+
+    for name in ("c++", "g++", "clang++", "cc", "gcc", "clang"):
+        if shutil.which(name):
+            return
+    sys.exit(
+        "Error: no C/C++ compiler was found, but torchcsprng's native extension "
+        "must be compiled from source.\n"
+        "On Ubuntu/Debian: sudo apt-get install build-essential\n"
+        "Then re-run `pip install -e . --no-build-isolation`."
+    )
+
+
 _ensure_submodules()
+_ensure_cpp_compiler()
+
+try:
+    import wheel  # noqa: F401
+except ImportError:
+    sys.exit(
+        "Error: the 'wheel' package is required to build NssMPClib with "
+        "--no-build-isolation, but it is not installed in this environment.\n"
+        "Install it first:\n"
+        "    pip install --upgrade setuptools wheel\n"
+        "Then re-run `pip install -e . --no-build-isolation`."
+    )
 
 try:
     import torch

--- a/tutorials/Tutorial_1_Two_Party_Computation.md
+++ b/tutorials/Tutorial_1_Two_Party_Computation.md
@@ -58,8 +58,8 @@ with PartyRuntime(party):
 
     # Both parties reconstruct (results match on both sides)
     reconstructed_x = share_x.recon().convert_to_real_field()
-    # Or specifically restore on party 0:
-    reconstructed_x = share_x.restore(target_id=0).convert_to_real_field()
+    # Or specifically recon on party 0:
+    reconstructed_x = share_x.recon(target_id=0).convert_to_real_field()
 ```
 
 #### Party 1
@@ -71,8 +71,8 @@ with PartyRuntime(party):
     
     # Both parties reconstruct (results match on both sides)
     reconstructed_x = share_x.recon().convert_to_real_field()
-    # Or specifically restore on party 0:
-    reconstructed_x = share_x.restore(target_id=0).convert_to_real_field()
+    # Or specifically recon on party 0:
+    reconstructed_x = share_x.recon(target_id=0).convert_to_real_field()
 ```
 
 ### 2. Arithmetic Operations
@@ -112,19 +112,19 @@ with PartyRuntime(party):
 with PartyRuntime(party):
     # Equality check
     share_z = share_x == share_y
-    result = share_z.restore().convert_to_real_field()
+    result = share_z.recon().convert_to_real_field()
     # Greater than or equal
     share_z = share_x >= share_y
-    result = share_z.restore().convert_to_real_field()
+    result = share_z.recon().convert_to_real_field()
     # Less than or equal
     share_z = share_x <= share_y
-    result = share_z.restore().convert_to_real_field()
+    result = share_z.recon().convert_to_real_field()
     # Strictly greater than
     share_z = share_x > share_y
-    result = share_z.restore().convert_to_real_field()
+    result = share_z.recon().convert_to_real_field()
     # Strictly less than
     share_z = share_x < share_y
-    result = share_z.restore().convert_to_real_field()
+    result = share_z.recon().convert_to_real_field()
 ```
 
 ### 4. Advanced Mathematical Functions (Each Party executes symmetrically)
@@ -158,7 +158,7 @@ with PartyRuntime(party):
 
 4. **Beaver Triples**: Matrix multiplication requires pre-generated Beaver triples shared between parties.
 
-5. **Field Conversion**: Use `.convert_to_real_field()` after `.restore()` to get plaintext results.
+5. **Field Conversion**: Use `.convert_to_real_field()` after `.recon()` to get plaintext results.
 
 6. **Tolerance**: Due to fixed-point arithmetic, use appropriate tolerances when comparing results:
    ```python

--- a/tutorials/Tutorial_2_Three_Party_Computation.md
+++ b/tutorials/Tutorial_2_Three_Party_Computation.md
@@ -173,27 +173,27 @@ with PartyRuntime(party):
 with PartyRuntime(party):
     # Equality check
     share_z = share_x == share_y
-    result = share_z.restore().convert_to_real_field()
+    result = share_z.recon().convert_to_real_field()
     print("x == y:", result)
     
     # Greater than or equal
     share_z = share_x >= share_y
-    result = share_z.restore().convert_to_real_field()
+    result = share_z.recon().convert_to_real_field()
     print("x >= y:", result)
     
     # Less than or equal
     share_z = share_x <= share_y
-    result = share_z.restore().convert_to_real_field()
+    result = share_z.recon().convert_to_real_field()
     print("x <= y:", result)
     
     # Strictly greater than
     share_z = share_x > share_y
-    result = share_z.restore().convert_to_real_field()
+    result = share_z.recon().convert_to_real_field()
     print("x > y:", result)
     
     # Strictly less than
     share_z = share_x < share_y
-    result = share_z.restore().convert_to_real_field()
+    result = share_z.recon().convert_to_real_field()
     print("x < y:", result)
 ```
 
@@ -233,7 +233,7 @@ with PartyRuntime(party):
 
 4. **Synchronization**: All three parties must execute corresponding operations in the same order and within their respective runtime contexts.
 
-5. **Field Conversion**: Use `.convert_to_real_field()` after `.restore()` to get plaintext results.
+5. **Field Conversion**: Use `.convert_to_real_field()` after `.recon()` to get plaintext results.
 
 6. **Security Mode Differences**:
    - `HONEST_MAJORITY`: Can tolerate one malicious party, slightly more overhead


### PR DESCRIPTION
This PR improves CUDA path discovery in csprng/setup.py so that torchcsprng can build correctly in conda/miniforge and PyTorch/NVIDIA CUDA wheel environments.

Previously, the build script mainly relied on traditional CUDA paths such as /usr/local/cuda-*. However, with modern PyTorch CUDA wheels, CUDA headers and libraries may be installed under:

site-packages/nvidia/*/include
site-packages/nvidia/*/lib

This could cause CUDA extension builds to fail with errors such as:

fatal error: cublas_v2.h: No such file or directory

This PR:

Adds CUDA discovery from CUDA_HOME, CUDA_PATH, CONDA_PREFIX, and /usr/local/cuda*
Adds support for site-packages/nvidia/*/include and site-packages/nvidia/*/lib
Passes CUDA include/library paths explicitly to CUDAExtension and nvcc
Adds early checks for cuda_runtime.h and cublas_v2.h
Supports NSSMPC_SKIP_CSPRNG_CUDA=1 to skip the CUDA build for torchcsprng

This change only affects the build process and does not change runtime behavior.